### PR TITLE
Fix multisampling when webgl2 is not supported

### DIFF
--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -3,6 +3,7 @@ import React, { forwardRef, useMemo, useEffect, createContext, useRef, useImpera
 import { useThree, useFrame } from 'react-three-fiber'
 import { EffectComposer as EffectComposerImpl, RenderPass, EffectPass, NormalPass } from 'postprocessing'
 import { HalfFloatType, TextureDataType } from 'three'
+import { isWebGL2Available } from './util'
 
 export const EffectComposerContext = createContext<{
   composer: EffectComposerImpl
@@ -47,7 +48,7 @@ const EffectComposer = React.memo(
         const effectComposer = new EffectComposerImpl(gl, {
           depthBuffer,
           stencilBuffer,
-          multisampling,
+          multisampling: isWebGL2Available() ? multisampling : 0,
           frameBufferType,
         })
         // Add render pass

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -32,3 +32,12 @@ export const useVector2 = (props: any, key: string): Vector2 => {
     }
   }, [vec])
 }
+
+export const isWebGL2Available = () => {
+  try {
+    var canvas = document.createElement('canvas')
+    return !!(window.WebGL2RenderingContext && canvas.getContext('webgl2'))
+  } catch (e) {
+    return false
+  }
+}


### PR DESCRIPTION
Using the `isWebGL2Available()` function from Three.js, this fixes things on Safari until they support webgl2.

Fixes #28