### PR TITLE
renamed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # react-postprocessing
 
-![npm](https://img.shields.io/npm/v/react-postprocessing?label=npm%20package&style=flat-square) ![npm](https://img.shields.io/npm/dt/react-postprocessing?style=flat-square) [![Discord Shield](https://discordapp.com/api/guilds/740090768164651008/widget.png?style=shield)](https://discord.gg/ZZjjNvJ)
+![npm](https://img.shields.io/npm/v/@react-three/postprocessing?label=npm%20package&style=flat-square) ![npm](https://img.shields.io/npm/dt/@react-three/postprocessing?style=flat-square) [![Discord Shield](https://discordapp.com/api/guilds/740090768164651008/widget.png?style=shield)](https://discord.gg/ZZjjNvJ)
 
-`react-postprocessing` is a [postprocessing](https://vanruesc.github.io/postprocessing) wrapper for [react-three-fiber](https://github.com/react-spring/react-three-fiber). This is not (yet) meant for complex orchestration of effects, but can save you [hundreds of LOC](https://twitter.com/0xca0a/status/1289501594698960897) for a straight forward effects-chain.
+`react-postprocessing` is a [postprocessing](https://vanruesc.github.io/postprocessing) wrapper for [react-three-fiber](https://github.com/pmndrs/react-three-fiber). This is not (yet) meant for complex orchestration of effects, but can save you [hundreds of LOC](https://twitter.com/0xca0a/status/1289501594698960897) for a straight forward effects-chain.
 
 ```bash
-npm install react-postprocessing
+npm install @react-three/postprocessing
 ```
 <p align="center">
   <a href="https://m94xb.csb.app" target="_blank"><img width="274" src="./examples/src/demos/Bubbles/resources/screenshot.jpg" alt="Bubbles" /></a>
@@ -52,9 +52,7 @@ function App() {
   )
 }
 ```
-    
+
 #### Documentation
-
-[react-postprocessing exports](https://github.com/react-spring/react-postprocessing/blob/master/api.md)
-
-[postprocessing docs](https://vanruesc.github.io/postprocessing/public/docs/)
+- [react-postprocessing exports](https://github.com/react-spring/react-postprocessing/blob/master/api.md)
+- [postprocessing docs](https://vanruesc.github.io/postprocessing/public/docs/)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # react-postprocessing
 
-![npm](https://img.shields.io/npm/v/@react-three/postprocessing?label=npm%20package&style=flat-square) ![npm](https://img.shields.io/npm/dt/@react-three/postprocessing?style=flat-square) [![Discord Shield](https://discordapp.com/api/guilds/740090768164651008/widget.png?style=shield)](https://discord.gg/ZZjjNvJ)
+![npm](https://img.shields.io/npm/v/react-three/postprocessing?label=npm%20package&style=flat-square) ![npm](https://img.shields.io/npm/dt/react-three/postprocessing?style=flat-square) [![Discord Shield](https://discordapp.com/api/guilds/740090768164651008/widget.png?style=shield)](https://discord.gg/ZZjjNvJ)
 
 `react-postprocessing` is a [postprocessing](https://vanruesc.github.io/postprocessing) wrapper for [react-three-fiber](https://github.com/pmndrs/react-three-fiber). This is not (yet) meant for complex orchestration of effects, but can save you [hundreds of LOC](https://twitter.com/0xca0a/status/1289501594698960897) for a straight forward effects-chain.
 
@@ -35,7 +35,7 @@ Well, you can do pretty much anything, but here's an example combining a couple 
 
 ```jsx
 import React from 'react'
-import { EffectComposer, DepthOfField, Bloom, Noise, Vignette } from 'react-postprocessing'
+import { EffectComposer, DepthOfField, Bloom, Noise, Vignette } from '@react-three/postprocessing'
 import { Canvas } from 'react-three-fiber'
 
 function App() {
@@ -54,5 +54,5 @@ function App() {
 ```
 
 #### Documentation
-- [react-postprocessing exports](https://github.com/react-spring/react-postprocessing/blob/master/api.md)
+- [react-postprocessing exports](https://github.com/pmndrs/react-postprocessing/blob/master/api.md)
 - [postprocessing docs](https://vanruesc.github.io/postprocessing/public/docs/)

--- a/examples/config-overrides.js
+++ b/examples/config-overrides.js
@@ -10,13 +10,13 @@ module.exports = (config, env) => {
     babelInclude([path.resolve('src'), path.resolve('../src')]),
     process.env.ALIAS_PP &&
       addWebpackAlias({
-        'react-postprocessing': path.resolve('../src/index'),
+        '@react-three/postprocessing': path.resolve('../src/index'),
         postprocessing: path.resolve('node_modules/postprocessing'),
         react: path.resolve('node_modules/react'),
         'react-dom': path.resolve('node_modules/react-dom'),
         'react-scheduler': path.resolve('node_modules/react-scheduler'),
         'react-three-fiber': path.resolve('node_modules/react-three-fiber'),
-        drei: path.resolve('node_modules/drei'),
+        '@react-three/drei': path.resolve('node_modules/@react-three/drei'),
       })
   )(config, env)
 }

--- a/examples/package.json
+++ b/examples/package.json
@@ -22,7 +22,7 @@
     "react-router": "5.2.0",
     "react-router-dom": "^5.1.5",
     "react-scripts": "3.4.1",
-    "react-three-fiber": "^5.0.0",
+    "react-three-fiber": "^5.0.1",
     "react-three-gui": "^0.1.5",
     "react-use-gesture": "^7.0.15",
     "styled-components": "^5.1.1",

--- a/examples/package.json
+++ b/examples/package.json
@@ -12,21 +12,21 @@
   "dependencies": {
     "@react-spring/core": "^9.0.0-rc.3",
     "@react-spring/three": "^9.0.0-rc.3",
+    "@react-three/drei": "^1.5.7",
+    "@react-three/postprocessing": "^1.4.0",
     "classnames": "2.2.6",
-    "drei": "^0.0.71",
     "immer": "^7.0.8",
     "postprocessing": "^6.16.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-postprocessing": "^1.1.4",
     "react-router": "5.2.0",
     "react-router-dom": "^5.1.5",
     "react-scripts": "3.4.1",
-    "react-three-fiber": "^5.0.0-beta.11",
+    "react-three-fiber": "^5.0.0",
     "react-three-gui": "^0.1.5",
     "react-use-gesture": "^7.0.15",
     "styled-components": "^5.1.1",
-    "three": "^0.119.1"
+    "three": "^0.120.1"
   },
   "devDependencies": {
     "@types/react-router": "^5.1.8",

--- a/examples/src/demos/Bubbles/index.tsx
+++ b/examples/src/demos/Bubbles/index.tsx
@@ -2,7 +2,7 @@ import * as THREE from 'three'
 import React, { Suspense, useRef, useState } from 'react'
 import { Canvas, useFrame, useResource } from 'react-three-fiber'
 import { EffectComposer, DepthOfField, Bloom, Noise, Vignette } from 'react-postprocessing'
-import { Html, Icosahedron, useTextureLoader, useCubeTextureLoader, MeshDistortMaterial } from 'drei'
+import { Html, Icosahedron, useTextureLoader, useCubeTextureLoader, MeshDistortMaterial } from '@react-three/drei'
 import { LoadingMsg } from '../../styles'
 import bumpMapUrl from './resources/bump.jpg'
 

--- a/examples/src/demos/Selection/index.tsx
+++ b/examples/src/demos/Selection/index.tsx
@@ -1,8 +1,8 @@
 import * as THREE from 'three'
 import React, { useRef, useState, useCallback } from 'react'
-import { EffectComposer, Outline, SelectiveBloom } from 'react-postprocessing'
+import { EffectComposer, Outline, SelectiveBloom } from '@react-three/postprocessing'
 import { Canvas, useFrame } from 'react-three-fiber'
-import { Sphere, Box } from 'drei'
+import { Sphere, Box } from '@react-three/drei'
 
 import { Mesh } from 'three'
 

--- a/examples/src/demos/TakeControl/Effects.tsx
+++ b/examples/src/demos/TakeControl/Effects.tsx
@@ -1,10 +1,10 @@
 import React, { Suspense, forwardRef } from 'react'
 
-import { EffectComposer, Noise, Vignette, HueSaturation, GodRays } from 'react-postprocessing'
+import { EffectComposer, Noise, Vignette, HueSaturation, GodRays } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
 import { useResource } from 'react-three-fiber'
 
-import { Circle } from 'drei'
+import { Circle } from '@react-three/drei'
 import { useControl } from 'react-three-gui'
 
 const Sun = forwardRef(function Sun(props, forwardRef) {

--- a/examples/src/demos/TakeControl/Scene.tsx
+++ b/examples/src/demos/TakeControl/Scene.tsx
@@ -1,6 +1,6 @@
 import * as THREE from 'three'
 import React, { useMemo, useRef } from 'react'
-import { Extrude, OrbitControls } from 'drei'
+import { Extrude, OrbitControls } from '@react-three/drei'
 import { useControl } from 'react-three-gui'
 import { useFrame } from 'react-three-fiber'
 import { useSprings } from '@react-spring/core'

--- a/examples/src/demos/TakeControl/index.tsx
+++ b/examples/src/demos/TakeControl/index.tsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react'
 import { Canvas } from 'react-three-fiber'
-import { Html, Stats } from 'drei'
+import { Html, Stats } from '@react-three/drei'
 import Effects from './Effects'
 import Scene from './Scene'
 import { Controls } from 'react-three-gui'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-postprocessing",
+  "name": "@react-three/postprocessing",
   "version": "1.4.0",
   "description": "postprocessing wrapper for React and react-three-fiber",
   "keywords": [
@@ -82,7 +82,7 @@
     "prettier": "^2.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^4.2.20",
+    "react-three-fiber": "^5.0.0",
     "rimraf": "^3.0.2",
     "rollup": "^2.28.1",
     "rollup-plugin-size-snapshot": "^0.12.0",
@@ -94,7 +94,7 @@
   "peerDependencies": {
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^4.2.21",
+    "react-three-fiber": ">=5.0",
     "three": "^0.120.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prettier": "^2.1.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
-    "react-three-fiber": "^5.0.0",
+    "react-three-fiber": "^5.0.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.28.1",
     "rollup-plugin-size-snapshot": "^0.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1422,10 +1422,10 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@juggle/resize-observer@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.1.3.tgz#d7373eb9a1afc371342b8cf1a07e34368f3d65d7"
-  integrity sha512-y7qc6SzZBlSpx8hEDfV0S9Cx6goROX/vBhS2Ru1Q78Jp1FlCMbxp7UcAN90rLgB3X8DSMBgDFxcmoG/VfdAhFA==
+"@juggle/resize-observer@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@juggle/resize-observer/-/resize-observer-3.2.0.tgz#5e0b448d27fe3091bae6216456512c5904d05661"
+  integrity sha512-fsLxt0CHx2HCV9EL8lDoVkwHffsA0snUpddYjdLyXcG5E41xaamn9ZyQqOE9TUJdrRlH8/hjIf+UdOdDeKCUgg==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
@@ -3769,15 +3769,15 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
-  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
-
 fast-deep-equal@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -6323,53 +6323,40 @@ react-is@^16.12.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-merge-refs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.0.0.tgz#d6b297b9a62a266460a3c0d8b9d920731d8bbe63"
-  integrity sha512-VkvWuCR5VoTjb+VYUcOjkFo66HDv1Hw8VjKcwQtWr2lJnT8g7epRRyfz8+Zkl2WhwqNeqR0gIe0XYrBa9ePeXg==
-
 react-merge-refs@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-promise-suspense@^0.3.2:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/react-promise-suspense/-/react-promise-suspense-0.3.3.tgz#b085c7e0ac22b85fd3d605b1c4f181cda4310bc9"
-  integrity sha512-OdehKsCEWYoV6pMcwxbvJH99UrbXylmXJ1QpEL9OfHaUBzcAihyfSJV8jFq325M/wW9iKc/BoiLROXxMul+MxA==
-  dependencies:
-    fast-deep-equal "^2.0.1"
-
-react-reconciler@0.25.1:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.25.1.tgz#f9814d59d115e1210762287ce987801529363aaa"
-  integrity sha512-R5UwsIvRcSs3w8n9k3tBoTtUHdVhu9u84EG7E5M0Jk9F5i6DA1pQzPfUZd6opYWGy56MJOtV3VADzy6DRwYDjw==
+react-reconciler@0.26.0-rc.0:
+  version "0.26.0-rc.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.0-rc.0.tgz#a409088732dd20aafb008f68d1d15e37b9c26329"
+  integrity sha512-Q1YbFz4PXvD9YVxE4/YQXtEw0OLg53sLr9dsquAnGMtt99hiOTF9xTr4Z2GjF7pTaU6KA1DHLoyh6Nng+d6N3g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "0.20.0-rc.0"
 
-react-three-fiber@^4.2.20:
-  version "4.2.20"
-  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-4.2.20.tgz#2689c005689f7c706cfb29bcf7f09958ff900b9a"
-  integrity sha512-M5TCdGNKvofe37VMXnhbabgRDiRm9rnfxOmMFuLa+H9FiiLT3wUMMgE9eBmLh3McKgYXURETWKkNDePeQ0J0JQ==
+react-three-fiber@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-three-fiber/-/react-three-fiber-5.0.0.tgz#d519505024c883db2dc8d1b90a98a49aa95aefa2"
+  integrity sha512-EHqmljYhbtKl1ZXgoYzhwTDyJRRn2X2w4DTdINwI6+w5Jei5aiRSYp3avoDDKafEBmb/uDt2xejY3wQ1GfhFCQ==
   dependencies:
-    "@babel/runtime" "^7.9.2"
-    "@juggle/resize-observer" "^3.1.3"
-    react-merge-refs "^1.0.0"
-    react-promise-suspense "^0.3.2"
-    react-reconciler "0.25.1"
-    react-use-measure "^2.0.0"
+    "@babel/runtime" "^7.11.2"
+    "@juggle/resize-observer" "^3.2.0"
+    react-merge-refs "^1.1.0"
+    react-reconciler "0.26.0-rc.0"
+    react-use-measure "^2.0.1"
     resize-observer-polyfill "^1.5.1"
-    scheduler "0.19.1"
+    scheduler "0.20.0-rc.0"
     tiny-emitter "^2.1.0"
+    use-asset "^0.1.1"
     utility-types "^3.10.0"
 
-react-use-measure@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.0.tgz#f49b5cbde4cc18f5061d726a8a3db9fcd2244998"
-  integrity sha512-aYosukh38+eqjgNExd/OKEM0n5YSbl5niYYq3OAUWywf3deUjpnVfGMnwTmjF32+Owqr1sc3KKZku9n72lAaPA==
+react-use-measure@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-use-measure/-/react-use-measure-2.0.1.tgz#4f23f94c832cd4512da55acb300d1915dcbf3ae8"
+  integrity sha512-lFfHiqcXbJ2/6aUkZwt8g5YYM7EGqNVxJhMqMPqv1BVXRKp8D7jYLlmma0SvhRY4WYxxkZpCdbJvhDylb5gcEA==
   dependencies:
     debounce "^1.2.0"
 
@@ -6782,7 +6769,15 @@ saxes@^5.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@0.19.1, scheduler@^0.19.1:
+scheduler@0.20.0-rc.0:
+  version "0.20.0-rc.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.0-rc.0.tgz#9cb397f88f9decea28d159d3aad068b54a6f35e4"
+  integrity sha512-5CZiVhk9xI9VmqaodZH+eO3aKgqYwjZ8uf9lnfRlYEwaB4lbmIq0mzuNY5w52sbPlZP9pifXQaLGudKHMgQZcw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
+scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
   integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
@@ -7691,6 +7686,13 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-asset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/use-asset/-/use-asset-0.1.1.tgz#cc6835c36ee1b9cc79708d4c8fa954a62d55bc1c"
+  integrity sha512-HSBywtDxITn7xxc3AK3phkhtaD05w1X/9sjnIfrQcDPRCVpgJ2Z+Bg1ixK5PB3c81nuAuTXRgMGzRvGoztdDlg==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
Renamed package to match the new `@react-three/*` namespace.

❗ These packages need to be published at their current version. ❗
❗ I have only renamed the dependencies in the various packages, I have not adjusted the version number. If we bump the version before these PRs get merged, we will need to also change it in each package within the ecosystem. ❗ 

## Next Steps:
- [x] Do a fresh `yarn install` to regenerate the `yarn.lock` file.
- [x] Create a dist for the **current version** (see ❗ warning above)
- [x] Publish the package to npm. This should publish it under the `@react-three/*` namespace.
  - You may need to add the `--access public` option or something similar since scoped packages are by default private. See https://docs.npmjs.com/creating-and-publishing-scoped-public-packages#publishing-scoped-public-packages for more details
- [x] Commit the new `yarn.lock` file back to this branch.
- [x] Merge the PR.

**Note:** Some of these packages have dependencies on each other. If you run into a "package not found" error when attempting to `yarn install`, you might need to run through these steps on a dependent package first. These PRs **will likely fail any automated build process** if they have dependencies on other packages that need to be published first.