### PR TITLE
Fix type definitions for forwardRef components

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -59,7 +59,7 @@
       },
       "alias": {
         "extensions": [".js", ".jsx", ".ts", ".tsx", ".json"],
-        "map": [["react-postprocessing", "./src/index.tsx"]]
+        "map": [["@react-three/postprocessing", "./src/index.tsx"]]
       }
     }
   },

--- a/examples/src/demos/Bubbles/index.tsx
+++ b/examples/src/demos/Bubbles/index.tsx
@@ -70,7 +70,7 @@ function Scene() {
   const envMap = useCubeTextureLoader([cubePxUrl, cubeNxUrl, cubePyUrl, cubeNyUrl, cubePzUrl, cubeNzUrl], { path: '' })
 
   // We use `useResource` to be able to delay rendering the spheres until the material is ready
-  const [matRef, material] = useResource()
+  const matRef = useResource()
 
   return (
     <>
@@ -87,7 +87,7 @@ function Scene() {
         radius={1}
         distort={0.4}
       />
-      {material && <Instances material={material} />}
+      {matRef.current && <Instances material={matRef.current} />}
     </>
   )
 }

--- a/examples/src/demos/Bubbles/index.tsx
+++ b/examples/src/demos/Bubbles/index.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 import React, { Suspense, useRef, useState } from 'react'
 import { Canvas, useFrame, useResource } from 'react-three-fiber'
-import { EffectComposer, DepthOfField, Bloom, Noise, Vignette } from 'react-postprocessing'
+import { EffectComposer, DepthOfField, Bloom, Noise, Vignette } from '@react-three/postprocessing'
 import { Html, Icosahedron, useTextureLoader, useCubeTextureLoader, MeshDistortMaterial } from '@react-three/drei'
 import { LoadingMsg } from '../../styles'
 import bumpMapUrl from './resources/bump.jpg'

--- a/examples/src/demos/TakeControl/Effects.tsx
+++ b/examples/src/demos/TakeControl/Effects.tsx
@@ -1,11 +1,10 @@
-import React, { Suspense, forwardRef } from 'react'
-
+import { Circle } from '@react-three/drei'
 import { EffectComposer, Noise, Vignette, HueSaturation, GodRays } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
+import React, { Suspense, forwardRef } from 'react'
 import { useResource } from 'react-three-fiber'
-
-import { Circle } from '@react-three/drei'
 import { useControl } from 'react-three-gui'
+import { Mesh } from 'three'
 
 const Sun = forwardRef(function Sun(props, forwardRef) {
   const sunColor = useControl('sun color', { type: 'color', value: '#FF0000' })
@@ -18,7 +17,7 @@ const Sun = forwardRef(function Sun(props, forwardRef) {
 })
 
 function Effects() {
-  const [$sun, sun] = useResource()
+  const sunRef = useResource<Mesh>()
 
   const hue = useControl('Hue', {
     group: 'Postprocessing - HueSaturation',
@@ -67,11 +66,11 @@ function Effects() {
 
   return (
     <Suspense fallback={null}>
-      <Sun ref={$sun} />
+      <Sun ref={sunRef} />
 
-      {sun && (
+      {sunRef.current && (
         <EffectComposer multisampling={0}>
-          <GodRays sun={$sun.current} exposure={exposure} decay={decay} blur={blur} />
+          <GodRays sun={sunRef.current} exposure={exposure} decay={decay} blur={blur} />
 
           <Noise
             opacity={noise}

--- a/src/effects/ColorAverage.tsx
+++ b/src/effects/ColorAverage.tsx
@@ -1,11 +1,11 @@
 import { ColorAverageEffect, BlendFunction } from 'postprocessing'
-import React, { Ref, ForwardRefExoticComponent, forwardRef, useMemo } from 'react'
+import React, { Ref, forwardRef, useMemo } from 'react'
 
 export type ColorAverageProps = Partial<{
   blendFunction: BlendFunction
 }>
 
-export const ColorAverage: ForwardRefExoticComponent<ColorAverageProps> = forwardRef(function ColorAverage(
+export const ColorAverage = forwardRef<ColorAverageEffect, ColorAverageProps>(function ColorAverage(
   { blendFunction = BlendFunction.NORMAL }: ColorAverageProps,
   ref: Ref<ColorAverageEffect>
 ) {

--- a/src/effects/Glitch.tsx
+++ b/src/effects/Glitch.tsx
@@ -1,5 +1,5 @@
 import { GlitchEffect, GlitchMode } from 'postprocessing'
-import React, { Ref, ForwardRefExoticComponent, forwardRef, useMemo, useLayoutEffect } from 'react'
+import React, { Ref, forwardRef, useMemo, useLayoutEffect } from 'react'
 import { ReactThreeFiber } from 'react-three-fiber'
 import { useVector2 } from '../util'
 
@@ -13,7 +13,7 @@ export type GlitchProps = ConstructorParameters<typeof GlitchEffect>[0] &
     strength: ReactThreeFiber.Vector2
   }>
 
-export const Glitch: ForwardRefExoticComponent<GlitchEffect> = forwardRef(function Glitch(
+export const Glitch = forwardRef<GlitchEffect, GlitchProps>(function Glitch(
   { active, ...props }: GlitchProps,
   ref: Ref<GlitchEffect>
 ) {

--- a/src/effects/Pixelation.tsx
+++ b/src/effects/Pixelation.tsx
@@ -1,11 +1,11 @@
-import React, { ForwardRefExoticComponent, forwardRef, useMemo, Ref } from 'react'
+import React, { forwardRef, useMemo, Ref } from 'react'
 import { PixelationEffect } from 'postprocessing'
 
 export type PixelationProps = {
   granularity?: number
 }
 
-export const Pixelation: ForwardRefExoticComponent<PixelationProps> = forwardRef(function Pixelation(
+export const Pixelation = forwardRef<PixelationEffect, PixelationProps>(function Pixelation(
   { granularity = 5 }: PixelationProps,
   ref: Ref<PixelationEffect>
 ) {

--- a/src/effects/SSAO.tsx
+++ b/src/effects/SSAO.tsx
@@ -1,11 +1,11 @@
-import React, { Ref, ForwardRefExoticComponent, forwardRef, useContext, useMemo } from 'react'
+import React, { Ref, forwardRef, useContext, useMemo } from 'react'
 import { SSAOEffect, BlendFunction } from 'postprocessing'
 import { EffectComposerContext } from '../EffectComposer'
 
 // first two args are camera and texture
 type SSAOProps = ConstructorParameters<typeof SSAOEffect>[2]
 
-export const SSAO: ForwardRefExoticComponent<SSAOEffect> = forwardRef(function SSAO(
+export const SSAO = forwardRef<SSAOEffect, SSAOProps>(function SSAO(
   props: SSAOProps,
   ref: Ref<SSAOEffect>
 ) {

--- a/src/effects/Texture.tsx
+++ b/src/effects/Texture.tsx
@@ -1,5 +1,5 @@
 import { TextureEffect } from 'postprocessing'
-import React, { Ref, ForwardRefExoticComponent, forwardRef, useMemo, useLayoutEffect } from 'react'
+import React, { Ref, forwardRef, useMemo, useLayoutEffect } from 'react'
 import { useLoader } from 'react-three-fiber'
 import { TextureLoader, sRGBEncoding, RepeatWrapping } from 'three'
 
@@ -7,7 +7,7 @@ type TextureProps = ConstructorParameters<typeof TextureEffect>[0] & {
   textureSrc: string
 }
 
-export const Texture: ForwardRefExoticComponent<TextureProps> = forwardRef(function Texture(
+export const Texture = forwardRef<TextureEffect, TextureProps>(function Texture(
   { textureSrc, texture, ...props }: TextureProps,
   ref: Ref<TextureEffect>
 ) {

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useMemo, useLayoutEffect, ForwardRefExoticComponent } from 'react'
+import React, { forwardRef, useMemo, useLayoutEffect } from 'react'
 import { Vector2 } from 'three'
 import { ReactThreeFiber } from 'react-three-fiber'
 import { Effect, BlendFunction } from 'postprocessing'
@@ -8,8 +8,8 @@ type DefaultProps = Partial<{ blendFunction: BlendFunction; opacity: number }>
 export const wrapEffect = <T extends new (...args: any[]) => Effect>(
   effectImpl: T,
   defaultBlendMode: BlendFunction = BlendFunction.NORMAL
-): ForwardRefExoticComponent<ConstructorParameters<typeof effectImpl>[0] & DefaultProps> =>
-  forwardRef(function Wrap(
+) =>
+  forwardRef<T, ConstructorParameters<typeof effectImpl>[0] & DefaultProps>(function Wrap(
     { blendFunction, opacity, ...props }: React.PropsWithChildren<DefaultProps & ConstructorParameters<T>[0]>,
     ref
   ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "outDir": "dist",
     "paths": {
       "*": ["types/*"],
-      "react-postprocessing": ["./"]
+      "@react-three/postprocessing": ["./"]
     }
   },
   "include": ["./types/**/*", "./src/**/*"],


### PR DESCRIPTION
## TypeScript Changes
Attempting to assign a `ref` to any of these `ForwardRefExoticComponent` types will fail:

![image](https://user-images.githubusercontent.com/1865957/98036404-fb8e7400-1de7-11eb-8c1a-cdb046980dbc.png)

The reason is that `ref` doesn't actually exist as a property on `ForwardRefExoticComponent`, so we should avoid using that type. The better way to type `forwardRef` components is to use the generic arguments in `forwardRef<T, P>`, where `T` is the ref type and `P` is the props type.

See https://stackoverflow.com/questions/60052450/in-react-using-typescript-how-do-i-pass-a-ref-to-a-custom-component-using-reff for more info.

## Additional Fixes
This PR also fixes the Netlify deploy, which was broken by the package rename (some aliases needed to be updated). Once the deploy started working, I noticed the examples were crashing on startup due to a change in [`useResource`](https://github.com/pmndrs/react-three-fiber/commit/ce122cd79d973855904be975e9e49951d4bd7528#diff-a2d969770fbca6d31b2bcb062b5d406aa54f9ddebef57996faacc6f82e746e42), so I went ahead and patched that up too.