### PR TITLE
Add intensity and color to SSAO parameters.

### DIFF
--- a/src/effects/SSAO.tsx
+++ b/src/effects/SSAO.tsx
@@ -24,6 +24,8 @@ export const SSAO = forwardRef<SSAOEffect, SSAOProps>(function SSAO(props: SSAOP
       radius: 20,
       scale: 0.5,
       bias: 0.5,
+      intensity: 1.0,
+      color: null,
       ...props,
     })
   }, [camera, normalPass, props])

--- a/types/postprocessing.d.ts
+++ b/types/postprocessing.d.ts
@@ -2591,6 +2591,8 @@ declare module 'postprocessing' {
    * @param [options.radius = 18.25] - The occlusion sampling radius.
    * @param [options.scale = 1.0] - The scale of the ambient occlusion.
    * @param [options.bias = 0.0] - An occlusion bias.
+   * @param [options.intensity = 1.0] - The intensity of the ambient occlusion.
+   * @param [options.color = null] - The color of the ambient occlusion.
    */
   export class SSAOEffect extends Effect {
     constructor(
@@ -2608,6 +2610,8 @@ declare module 'postprocessing' {
         radius?: number
         scale?: number
         bias?: number
+        intensity?: number;
+        color?: string | null;
       }
     )
     /**


### PR DESCRIPTION
[Looking at this example](https://codesandbox.io/s/zxpv7?file=/src/App.js:2301-2367), I noticed that the properties `intensity` and `color` were missing from the `SSAOEffect` definition's constructor parameters. I've added them with the corresponding documentation from [the postprocessing website](https://vanruesc.github.io/postprocessing/public/docs/class/src/effects/SSAOEffect.js~SSAOEffect.html).