### PR TITLE
added gamma correction effect

### DIFF
--- a/src/effects/GammaCorrection.tsx
+++ b/src/effects/GammaCorrection.tsx
@@ -1,0 +1,4 @@
+import { GammaCorrectionEffect } from 'postprocessing'
+import { wrapEffect } from '../util'
+
+export const GammaCorrection = wrapEffect(GammaCorrectionEffect)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,5 +23,6 @@ export * from './effects/ToneMapping'
 export * from './effects/Vignette'
 export * from './effects/ShockWave'
 export * from './effects/LUT'
+export * from './effects/GammaCorrection'
 
 export { default as EffectComposer, EffectComposerContext } from './EffectComposer'


### PR DESCRIPTION
Per [this discussion](https://discord.com/channels/740090768164651008/741754170310131763/922283014476673074), adding gamma correction effect as export to react-pp.

I'm still wondering if this is the best solution to the problem encountered, as it seems like some output encoding issue involving render targets, but exporting here does provide a knob for an issue I and @richczhou encountered where color/tonemapping is off in certain custom shader scenes ([example](https://codesandbox.io/s/react-pp-weirdness-forked-stsyx?file=/src/App.js)).

this is my first contribution so I'm not sure if any other files need adjustments (e.g. postprocessing.d.ts ?)