### PR TITLE
fix Glitch and GlitchMode typings

### DIFF
--- a/src/effects/Glitch.tsx
+++ b/src/effects/Glitch.tsx
@@ -5,7 +5,7 @@ import { useVector2 } from '../util'
 
 export type GlitchProps = ConstructorParameters<typeof GlitchEffect>[0] &
   Partial<{
-    mode: typeof GlitchMode
+    mode: typeof GlitchMode[keyof typeof GlitchMode]
     active: boolean
     delay: ReactThreeFiber.Vector2
     duration: ReactThreeFiber.Vector2

--- a/types/postprocessing.d.ts
+++ b/types/postprocessing.d.ts
@@ -1981,10 +1981,10 @@ declare module 'postprocessing' {
    * @property CONSTANT_WILD - Constant wild glitches.
    */
   export const GlitchMode: {
-    DISABLED: number
-    SPORADIC: number
-    CONSTANT_MILD: number
-    CONSTANT_WILD: number
+    DISABLED: 0
+    SPORADIC: 1
+    CONSTANT_MILD: 2
+    CONSTANT_WILD: 3
   }
 
   /**


### PR DESCRIPTION
Hello everyone! 👋
I was not able to pass a number value to the `mode` prop at the `Glitch` component. 

I could whether decide to change the type to just a `number` type or add the values to the `GlitchMode` declarations and adjust the `mode` property. I preferred this solution as now the `mode` prop will only accept `0 | 1 | 2 | 3`.