### PR TITLE
fix: allow BlendFunction.SKIP in wrapEffect

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -22,7 +22,7 @@ export const wrapEffect = <T extends new (...args: any[]) => Effect>(
     const effect: Effect = useMemo(() => new effectImpl(props), [props])
 
     useLayoutEffect(() => {
-      effect.blendMode.blendFunction = blendFunction || defaultBlendMode
+      effect.blendMode.blendFunction = !blendFunction && blendFunction !== 0 ? defaultBlendMode : blendFunction
       if (opacity !== undefined) effect.blendMode.opacity.value = opacity
       invalidate()
     }, [blendFunction, effect.blendMode, opacity])


### PR DESCRIPTION
This PR fixes the current workflow when the effect wrapper's prop blendFunction is overwritten with defaultBlendMode if it is equal to 0, which is the value of BlendFunction.SKIP