### PR TITLE
fix(deps): unpin postprocessing

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "typegen": "tsc --emitDeclarationOnly || true"
   },
   "dependencies": {
-    "postprocessing": "6.26.3",
+    "postprocessing": "^6.26.4",
     "react-merge-refs": "^1.1.0",
     "three-stdlib": "^2.8.11"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3920,10 +3920,10 @@ pidtree@^0.5.0:
   resolved "https://registry.yarnpkg.com/pidtree/-/pidtree-0.5.0.tgz#ad5fbc1de78b8a5f99d6fbdd4f6e4eee21d1aca1"
   integrity sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==
 
-postprocessing@6.26.3:
-  version "6.26.3"
-  resolved "https://registry.yarnpkg.com/postprocessing/-/postprocessing-6.26.3.tgz#456922499e13e02352b3b6b14881ca8186e8a96a"
-  integrity sha512-f9VMDQSLngrdJByPjza4pNHZWoEnGFdxj6GsgqGd2+RM3PYFTCZapgpX9W/FspRUg6Is38vkUfjvLxWyfBHbhQ==
+postprocessing@^6.26.4:
+  version "6.26.4"
+  resolved "https://registry.yarnpkg.com/postprocessing/-/postprocessing-6.26.4.tgz#726c66feb09ca0517f578376682820c472054a21"
+  integrity sha512-8u3ERu8va0bhJ3E97r33tAqhMgOdX9ndSTQnL2KlNNOeO9L5h2w3Qi8UGzrU+R7s/Kwz51KxcB90XODcrpa0SA==
 
 potpack@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Unpins the postprocessing dependency to stay within the current major (https://github.com/pmndrs/react-postprocessing/issues/124#issuecomment-1117789682).