### PR TITLE
fix: drop react-dom peer dep, correctly flag targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "3d"
   ],
   "license": "MIT",
-  "main": "dist/index.cjs.js",
+  "type": "module",
+  "main": "dist/index.cjs",
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
@@ -84,12 +85,6 @@
   "peerDependencies": {
     "@react-three/fiber": ">=7.0",
     "react": ">=17.0",
-    "react-dom": ">=17.0",
     "three": ">=0.136.0"
-  },
-  "peerDependenciesMeta": {
-    "react-dom": {
-      "optional": true
-    }
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,7 @@ export default [
   },
   {
     input: `./src/index.tsx`,
-    output: { file: `dist/index.cjs.js`, format: 'cjs' },
+    output: { file: `dist/index.cjs`, format: 'cjs' },
     external,
     plugins: [json(), babel(getBabelOptions({ useESModules: false })), filesize(), resolve({ extensions })],
   },


### PR DESCRIPTION
Drops the unused `react-dom` peer dependency and fixes issues with Node target resolution.