### PR TITLE
fix: wrapEffect disposal & root context

### DIFF
--- a/src/effects/Bloom.tsx
+++ b/src/effects/Bloom.tsx
@@ -1,4 +1,4 @@
 import { BloomEffect, BlendFunction } from 'postprocessing'
 import { wrapEffect } from '../util'
 
-export const Bloom = wrapEffect(BloomEffect, BlendFunction.ADD)
+export const Bloom = wrapEffect(BloomEffect, { blendFunction: BlendFunction.ADD })

--- a/src/effects/Noise.tsx
+++ b/src/effects/Noise.tsx
@@ -1,4 +1,4 @@
 import { NoiseEffect, BlendFunction } from 'postprocessing'
 import { wrapEffect } from '../util'
 
-export const Noise = wrapEffect(NoiseEffect, BlendFunction.COLOR_DODGE)
+export const Noise = wrapEffect(NoiseEffect, { blendFunction: BlendFunction.COLOR_DODGE })

--- a/src/effects/ScanlineEffect.tsx
+++ b/src/effects/ScanlineEffect.tsx
@@ -1,4 +1,4 @@
 import { ScanlineEffect, BlendFunction } from 'postprocessing'
 import { wrapEffect } from '../util'
 
-export const Scanline = wrapEffect(ScanlineEffect, BlendFunction.OVERLAY)
+export const Scanline = wrapEffect(ScanlineEffect, { blendFunction: BlendFunction.OVERLAY })

--- a/src/effects/TiltShift.tsx
+++ b/src/effects/TiltShift.tsx
@@ -1,4 +1,4 @@
 import { TiltShiftEffect, BlendFunction } from 'postprocessing'
 import { wrapEffect } from '../util'
 
-export const TiltShift = wrapEffect(TiltShiftEffect, BlendFunction.ADD)
+export const TiltShift = wrapEffect(TiltShiftEffect, { blendFunction: BlendFunction.ADD })


### PR DESCRIPTION
Fixes #25 #42 #132 #157 #173

Creates a private element identifier via `extend` rather than the use of hooks/primitive since the latter does not dispose nor is managed by React. Consequently, wrapped effects can use the full featureset of React and R3F, including `args` and `attach`. I've defined getters/setters for any prop aliases and camera defaults from host context for effects that need them.

This is likely a breaking change since props do not extend constructor parameters as there is no consistent constructor signature. Most parameters are later configurable, but those that aren't would need to be destructured and passed to `args` or `key`.