### PR TITLE
improvements to TiltShift2 for adaptive size and quality

### DIFF
--- a/api.md
+++ b/api.md
@@ -412,7 +412,7 @@ return (
     blur={1} // Softness, in range of 0 to 1+
     taper={0.5} // The softness of the focus area edges, in range of 0 to 1+
     direction={[1, 1]} // Blur direction. Cannot be [0,0].
-    sampleCount={20} // Blur quality (number of samples). Min is 3. Max is 100.
+    sampleCount={10} // Blur quality (number of samples). Min is 3. Max is 100.
   />
 )
 ```

--- a/api.md
+++ b/api.md
@@ -412,7 +412,7 @@ return (
     blur={1} // Softness, in range of 0 to 1+
     taper={0.5} // The softness of the focus area edges, in range of 0 to 1+
     direction={[1, 1]} // Blur direction
-    sampleCount={20} // Blur quality (number of samples). Max is 100.
+    sampleCount={20} // Blur quality (number of samples). Min is 3. Max is 100.
   />
 )
 ```

--- a/api.md
+++ b/api.md
@@ -411,7 +411,7 @@ return (
     end={[0.5, 1.0]} // End point, defined as % of screen dimensions
     blur={1} // Softness, in range of 0 to 1+
     taper={0.5} // The softness of the focus area edges, in range of 0 to 1+
-    direction={[1, 1]} // Blur direction
+    direction={[1, 1]} // Blur direction. Cannot be [0,0].
     sampleCount={20} // Blur quality (number of samples). Min is 3. Max is 100.
   />
 )

--- a/api.md
+++ b/api.md
@@ -407,11 +407,12 @@ A slightly different implementation of the tilt shift effect. It uses a differen
 ```jsx
 return (
   <TiltShift2
-    start={[0.5, 0.0]} // Start point
-    end={[0.5, 1.0]} // End point
-    blur={20} // Softness
-    gradient={1100} // The softness of the focus area edges in pixels
-    delta={[1, 1]} // Uv offset
+    start={[0.5, 0.0]} // Start point, defined as % of screen dimensions
+    end={[0.5, 1.0]} // End point, defined as % of screen dimensions
+    blur={1} // Softness, in range of 0 to 1+
+    taper={0.5} // The softness of the focus area edges, in range of 0 to 1+
+    direction={[1, 1]} // Blur direction
+    sampleCount={20} // Blur quality (number of samples)
   />
 )
 ```

--- a/api.md
+++ b/api.md
@@ -412,7 +412,7 @@ return (
     blur={1} // Softness, in range of 0 to 1+
     taper={0.5} // The softness of the focus area edges, in range of 0 to 1+
     direction={[1, 1]} // Blur direction
-    sampleCount={20} // Blur quality (number of samples)
+    sampleCount={20} // Blur quality (number of samples). Max is 100.
   />
 )
 ```

--- a/src/effects/TiltShift2.tsx
+++ b/src/effects/TiltShift2.tsx
@@ -4,43 +4,58 @@ import { wrapEffect } from '../util'
 
 const TiltShiftShader = {
   fragmentShader: `
+
     // original shader by Evan Wallace
+
+    #define MAX_ITERATIONS 100
+
     uniform float blur;
-    uniform float gradient;
+    uniform float taper;
     uniform vec2 start;
     uniform vec2 end;
-    uniform vec2 delta;
+    uniform vec2 direction;
+    uniform int sampleCount;
 
     float random(vec3 scale, float seed) {
-      /* use the fragment position for a different seed per-pixel */
-      return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);
+        /* use the fragment position for a different seed per-pixel */
+        return fract(sin(dot(gl_FragCoord.xyz + seed, scale)) * 43758.5453 + seed);
     }
 
     void mainImage(const in vec4 inputColor, const in vec2 uv, out vec4 outputColor) {
-
         vec4 color = vec4(0.0);
         float total = 0.0;
         vec2 startPixel = vec2(start.x * resolution.x, start.y * resolution.y);
         vec2 endPixel = vec2(end.x * resolution.x, end.y * resolution.y);
+        float f_samples = float(sampleCount);
+        float half_samples = f_samples / 2.0;
+
+        // use screen diagonal to normalize blur radii
+        float maxScreenDistance = distance(vec2(0.0), resolution); // diagonal distance
+        float gradientRadius = taper * (maxScreenDistance);
+        float blurRadius = blur * (maxScreenDistance / 16.0);
 
         /* randomize the lookup values to hide the fixed number of samples */
         float offset = random(vec3(12.9898, 78.233, 151.7182), 0.0);
         vec2 normal = normalize(vec2(startPixel.y - endPixel.y, endPixel.x - startPixel.x));
-        float radius = smoothstep(0.0, 1.0, abs(dot(uv * resolution - startPixel, normal)) / gradient) * blur;
+        float radius = smoothstep(0.0, 1.0, abs(dot(uv * resolution - startPixel, normal)) / gradientRadius) * blurRadius;
 
         #pragma unroll_loop_start
-        for (float i = -3.0; i <= 3.0; i++) {
-            float percent = (i + offset - 0.5) / 3.0;
+        for (int i = 0; i <= MAX_ITERATIONS; i++) {
+            if (i >= sampleCount) { break; } // return early if over sample count
+            float f_i = float(i);
+            float s_i = -half_samples + f_i;
+            float percent = (s_i + offset - 0.5) / half_samples;
             float weight = 1.0 - abs(percent);
-            vec4 sample_t = texture2D(inputBuffer, uv + delta / resolution * percent * radius);
+            vec4 sample_i = texture2D(inputBuffer, uv + normalize(direction) / resolution * percent * radius);
             /* switch to pre-multiplied alpha to correctly blur transparent images */
-            sample_t.rgb *= sample_t.a;
-            color += sample_t * weight;
+            sample_i.rgb *= sample_i.a;
+            color += sample_i * weight;
             total += weight;
         }
         #pragma unroll_loop_end
 
         outputColor = color / total;
+
         /* switch back from pre-multiplied alpha */
         outputColor.rgb /= outputColor.a + 0.00001;
     }
@@ -49,22 +64,24 @@ const TiltShiftShader = {
 
 export class TiltShiftEffect extends Effect {
   constructor({
-    blendFunction = BlendFunction.ADD,
-    blur = 20.0,
-    gradient = 1100.0,
-    start = [0.5, 0.0],
-    end = [0.5, 1.0],
-    delta = [1, 1],
+    blendFunction = BlendFunction.Normal,
+    blur = 1.0, // [0, 1], can go beyond 1 for extra
+    taper = 0.5, // [0, 1], can go beyond 1 for extra
+    start = [0.01, 0.01], // [0,1] percentage x,y of screenspace
+    end = [1.0, 1.0], // [0,1] percentage x,y of screenspace
+    sampleCount = 40.0, // number of blur samples
+    direction = [1, 1] // direction of blur
   } = {}) {
     super('TiltShiftEffect', TiltShiftShader.fragmentShader, {
       blendFunction,
       attributes: EffectAttribute.CONVOLUTION,
       uniforms: new Map([
         ['blur', new Uniform(blur)],
-        ['gradient', new Uniform(gradient)],
+        ['taper', new Uniform(taper)],
         ['start', new Uniform(start)],
         ['end', new Uniform(end)],
-        ['delta', new Uniform(delta)],
+        ['sampleCount', new Uniform(sampleCount)],
+        ['direction', new Uniform(direction)]
       ])
     })
   }

--- a/src/effects/TiltShift2.tsx
+++ b/src/effects/TiltShift2.tsx
@@ -67,9 +67,9 @@ export class TiltShiftEffect extends Effect {
     blendFunction = BlendFunction.Normal,
     blur = 1.0, // [0, 1], can go beyond 1 for extra
     taper = 0.5, // [0, 1], can go beyond 1 for extra
-    start = [0.01, 0.01], // [0,1] percentage x,y of screenspace
-    end = [1.0, 1.0], // [0,1] percentage x,y of screenspace
-    sampleCount = 40.0, // number of blur samples
+    start = [0.5, 0.0], // [0,1] percentage x,y of screenspace
+    end = [0.5, 1.0], // [0,1] percentage x,y of screenspace
+    sampleCount = 20.0, // number of blur samples
     direction = [1, 1] // direction of blur
   } = {}) {
     super('TiltShiftEffect', TiltShiftShader.fragmentShader, {

--- a/src/effects/TiltShift2.tsx
+++ b/src/effects/TiltShift2.tsx
@@ -69,7 +69,7 @@ export class TiltShiftEffect extends Effect {
     taper = 0.5, // [0, 1], can go beyond 1 for extra
     start = [0.5, 0.0], // [0,1] percentage x,y of screenspace
     end = [0.5, 1.0], // [0,1] percentage x,y of screenspace
-    sampleCount = 20.0, // number of blur samples
+    sampleCount = 10.0, // number of blur samples
     direction = [1, 1] // direction of blur
   } = {}) {
     super('TiltShiftEffect', TiltShiftShader.fragmentShader, {


### PR DESCRIPTION
**Improvements:**
- Sizes are now defined as a function of screen dimensions. Before `blur` and `gradient` sizes were defined in pixel values but now are in line with "start" and "end" which are defined as percentages of screen space. 
  - `gradient` prop / uniform is renamed to `taper` to clarify this distinction
  - You can go over 100% for the sizes and it should still work
- Blur size and focus area are now normalized by the size of the diagonal, this makes the effect (1) screen size adaptive if canvas size is changing (2) more consistent effect across portrait and landscape modes (3) more resilient to canvas `dpr` changes
- Introduced `sampleCount` so we can adjust quality & effect cost at runtime
  - Added `#define` for `MAX_ITERATIONS`, which means it's impossible to have higher than 100 samples
- renamed `delta` to `direction`, which indicates the blur's direction
- normalize `direction` so that it does not affect blur size, only blur direction. 
  - **Note:**  direction should never be [0,0] which will turn off the effect entirely.
- [Normalized](https://en.wikipedia.org/wiki/Normalized_loop) the `for` loop which should help with long tail compatibility

Performance should be roughly similar or negligibly worse, the core algorithm is unchanged but we're doing a few more ops to be screen size adaptive, as well as an inner`if` statement to be able to change quality at runtime (e.g. for use with drei's `PerformanceMonitor`).

Example of it in action [here.](https://codesandbox.io/s/c8qtmc?file=/src/tiltshift.js)