### PR TITLE
fix: missing effect type definitions

### DIFF
--- a/src/effects/GodRays.tsx
+++ b/src/effects/GodRays.tsx
@@ -1,8 +1,7 @@
 import { GodRaysEffect } from 'postprocessing'
-import React, { Ref, forwardRef, useMemo, useContext } from 'react'
+import React, { Ref, forwardRef, useMemo, useContext, useLayoutEffect } from 'react'
 import { Mesh, Points } from 'three'
 import { EffectComposerContext } from '../EffectComposer'
-import { useLayoutEffect } from 'react'
 import { resolveRef } from '../util'
 
 type GodRaysProps = ConstructorParameters<typeof GodRaysEffect>[2] & {

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -21,38 +21,35 @@ export type EffectProps<T extends EffectConstructor> = ReactThreeFiber.Node<
 let i = 0
 const components = new WeakMap<EffectConstructor, React.ExoticComponent<any> | string>()
 
-export const wrapEffect = <T extends EffectConstructor>(
-  effect: T,
-  defaults?: EffectProps<T>
- ) =>
+export const wrapEffect = <T extends EffectConstructor>(effect: T, defaults?: EffectProps<T>) =>
   /* @__PURE__ */ React.forwardRef<T, EffectProps<T>>(function Effect(
-  { blendFunction = defaults?.blendFunction, opacity = defaults?.opacity, ...props },
-  ref
+    { blendFunction = defaults?.blendFunction, opacity = defaults?.opacity, ...props },
+    ref
   ) {
-  let Component = components.get(effect)
-  if (!Component) {
-  const key = `@react-three/postprocessing/${effect.name}-${i++}`
-  extend({ [key]: effect })
-  components.set(effect, (Component = key))
-  }
- 
-  const camera = useThree((state) => state.camera)
-  const args = React.useMemo(
-  () => [...((defaults?.args ?? []) as any[]), ...((props.args ?? [{ ...defaults, ...props }]) as any[])],
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  [JSON.stringify(props)]
-  )
- 
-  return (
-  <Component
-  camera={camera}
-  blendMode-blendFunction={blendFunction}
-  blendMode-opacity={opacity}
-  {...props}
-  ref={ref}
-  args={args}
-  />
-  )
+    let Component = components.get(effect)
+    if (!Component) {
+      const key = `@react-three/postprocessing/${effect.name}-${i++}`
+      extend({ [key]: effect })
+      components.set(effect, (Component = key))
+    }
+
+    const camera = useThree((state) => state.camera)
+    const args = React.useMemo(
+      () => [...((defaults?.args ?? []) as any[]), ...((props.args ?? [{ ...defaults, ...props }]) as any[])],
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [JSON.stringify(props)]
+    )
+
+    return (
+      <Component
+        camera={camera}
+        blendMode-blendFunction={blendFunction}
+        blendMode-opacity={opacity}
+        {...props}
+        ref={ref}
+        args={args}
+      />
+    )
   })
 
 export const useVector2 = (props: Record<string, unknown>, key: string): THREE.Vector2 => {

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -21,38 +21,38 @@ export type EffectProps<T extends EffectConstructor> = ReactThreeFiber.Node<
 let i = 0
 const components = new WeakMap<EffectConstructor, React.ExoticComponent<any> | string>()
 
-export const wrapEffect = <T extends EffectConstructor, P extends EffectProps<T> = EffectProps<T>>(
+export const wrapEffect = <T extends EffectConstructor>(
   effect: T,
-  defaults?: P
-) =>
-  /* @__PURE__ */ React.forwardRef<T, P>(function Effect(
-    { blendFunction = defaults?.blendFunction, opacity = defaults?.opacity, ...props },
-    ref
+  defaults?: EffectProps<T>
+ ) =>
+  /* @__PURE__ */ React.forwardRef<T, EffectProps<T>>(function Effect(
+  { blendFunction = defaults?.blendFunction, opacity = defaults?.opacity, ...props },
+  ref
   ) {
-    let Component = components.get(effect)
-    if (!Component) {
-      const key = `@react-three/postprocessing/${effect.name}-${i++}`
-      extend({ [key]: effect })
-      components.set(effect, (Component = key))
-    }
-
-    const camera = useThree((state) => state.camera)
-    const args = React.useMemo(
-      () => [...((defaults?.args ?? []) as any[]), ...((props.args ?? [{ ...defaults, ...props }]) as any[])],
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [JSON.stringify(props)]
-    )
-
-    return (
-      <Component
-        camera={camera}
-        blendMode-blendFunction={blendFunction}
-        blendMode-opacity={opacity}
-        {...props}
-        ref={ref}
-        args={args}
-      />
-    )
+  let Component = components.get(effect)
+  if (!Component) {
+  const key = `@react-three/postprocessing/${effect.name}-${i++}`
+  extend({ [key]: effect })
+  components.set(effect, (Component = key))
+  }
+ 
+  const camera = useThree((state) => state.camera)
+  const args = React.useMemo(
+  () => [...((defaults?.args ?? []) as any[]), ...((props.args ?? [{ ...defaults, ...props }]) as any[])],
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  [JSON.stringify(props)]
+  )
+ 
+  return (
+  <Component
+  camera={camera}
+  blendMode-blendFunction={blendFunction}
+  blendMode-opacity={opacity}
+  {...props}
+  ref={ref}
+  args={args}
+  />
+  )
   })
 
 export const useVector2 = (props: Record<string, unknown>, key: string): THREE.Vector2 => {


### PR DESCRIPTION
### Issue:

When the effect type definitions were generated:

- with the `wrapEffect` function 
- and have default props passed to the function as the second argument

the types were incorrect.

Effects that were broken:

- Bloom
- Noise
- Scanline
- TiltShift
- TiltShift2