### PR TITLE
fix(wrapEffect): set blendmode opacity.value

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -44,7 +44,7 @@ export const wrapEffect = <T extends EffectConstructor>(effect: T, defaults?: Ef
       <Component
         camera={camera}
         blendMode-blendFunction={blendFunction}
-        blendMode-opacity={opacity}
+        blendMode-opacity-value={opacity}
         {...props}
         ref={ref}
         args={args}


### PR DESCRIPTION
Fixes a regression from #179 where `BlendEffect.opacity` is written to rather than `BlendEffect.opacity.value`.

https://github.com/pmndrs/postprocessing/blob/main/src/effects/blending/BlendMode.js#L113
