### PR TITLE
fix(Outline): don't stale invalidate

### DIFF
--- a/src/effects/Outline.tsx
+++ b/src/effects/Outline.tsx
@@ -61,7 +61,6 @@ export const Outline = forwardRef(function Outline(
       hiddenEdgeColor,
       kernelSize,
       patternTexture,
-      props,
       pulseSpeed,
       scene,
       visibleEdgeColor,


### PR DESCRIPTION
Fixes #205 by untracking props for the effect implementation. This should use `wrapEffect` instead to prevent issues like this.