### PR TITLE
fix(Glitch): set non-null chromatic offset

### DIFF
--- a/src/effects/Glitch.tsx
+++ b/src/effects/Glitch.tsx
@@ -22,6 +22,7 @@ export const Glitch = forwardRef<GlitchEffect, GlitchProps>(function Glitch(
   const delay = useVector2(props, 'delay')
   const duration = useVector2(props, 'duration')
   const strength = useVector2(props, 'strength')
+  const chromaticAberrationOffset = useVector2(props, 'chromaticAberrationOffset')
   const effect = useMemo(
     () => new GlitchEffect({ ...props, delay, duration, strength, chromaticAberrationOffset: new Vector2() }),
     [delay, duration, props, strength]

--- a/src/effects/Glitch.tsx
+++ b/src/effects/Glitch.tsx
@@ -25,7 +25,7 @@ export const Glitch = forwardRef<GlitchEffect, GlitchProps>(function Glitch(
   const chromaticAberrationOffset = useVector2(props, 'chromaticAberrationOffset')
   const effect = useMemo(
     () => new GlitchEffect({ ...props, delay, duration, strength, chromaticAberrationOffset }),
-    [delay, duration, props, strength]
+    [delay, duration, props, strength, chromaticAberrationOffset]
   )
   useLayoutEffect(() => {
     effect.mode = active ? props.mode || GlitchMode.SPORADIC : GlitchMode.DISABLED

--- a/src/effects/Glitch.tsx
+++ b/src/effects/Glitch.tsx
@@ -1,3 +1,4 @@
+import { Vector2 } from 'three'
 import { GlitchEffect, GlitchMode } from 'postprocessing'
 import { Ref, forwardRef, useMemo, useLayoutEffect } from 'react'
 import { ReactThreeFiber, useThree } from '@react-three/fiber'
@@ -22,7 +23,7 @@ export const Glitch = forwardRef<GlitchEffect, GlitchProps>(function Glitch(
   const duration = useVector2(props, 'duration')
   const strength = useVector2(props, 'strength')
   const effect = useMemo(
-    () => new GlitchEffect({ ...props, delay, duration, strength }),
+    () => new GlitchEffect({ ...props, delay, duration, strength, chromaticAberrationOffset: new Vector2() }),
     [delay, duration, props, strength]
   )
   useLayoutEffect(() => {

--- a/src/effects/Glitch.tsx
+++ b/src/effects/Glitch.tsx
@@ -24,7 +24,7 @@ export const Glitch = forwardRef<GlitchEffect, GlitchProps>(function Glitch(
   const strength = useVector2(props, 'strength')
   const chromaticAberrationOffset = useVector2(props, 'chromaticAberrationOffset')
   const effect = useMemo(
-    () => new GlitchEffect({ ...props, delay, duration, strength, chromaticAberrationOffset: new Vector2() }),
+    () => new GlitchEffect({ ...props, delay, duration, strength, chromaticAberrationOffset }),
     [delay, duration, props, strength]
   )
   useLayoutEffect(() => {


### PR DESCRIPTION
Fixes Glitch's `chromaticAbberationOffset` prop by creating a target for it.