### PR TITLE
fix: unpin peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,6 @@
   "peerDependencies": {
     "@react-three/fiber": ">=8.0",
     "react": ">=18.0",
-    "three": ">= 0.138.0 < 0.152.0"
+    "three": ">= 0.138.0"
   }
 }


### PR DESCRIPTION
Unpins peer deps. This should at least not specify a patch version, but since this is just wrapping postprocessing, we yield to its requirements.