### PR TITLE
fix(EffectComposer): split effects and passes

### DIFF
--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -123,7 +123,7 @@ export const EffectComposer = React.memo(
       const group = useRef(null)
       const instance = useInstanceHandle(group)
       useLayoutEffect(() => {
-        let passes: Pass[] = []
+        const passes: Pass[] = []
 
         if (group.current && instance.current && composer) {
           const children = instance.current.objects as unknown[]


### PR DESCRIPTION
Splits JSX children into an `EffectPass` or preserves them if they implement `Pass`. Other children are excluded and have no effect.

```jsx
<EffectComposer>
  <Effect />
  <Effect />
  <Pass />
  <Effect />
</EffectComposer>

// [EffectPass([Effect, Effect]), Pass, EffectPass([Effect])]
```