### PR TITLE
bump three-stdlib to v2.22.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "n8ao": "^1.4.1",
     "postprocessing": "^6.31.0",
     "screen-space-reflections": "2.5.0",
-    "three-stdlib": "^2.21.10"
+    "three-stdlib": "^2.22.10"
   },
   "devDependencies": {
     "@react-three/drei": "^9.68.2",


### PR DESCRIPTION
Noisy console error is propagating from `three-stdlib` which latest build resolves.
https://github.com/pmndrs/three-stdlib/issues/246