### PR TITLE
perf(Select): fix update loop

### DIFF
--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -28,7 +28,7 @@ export function Select({ enabled = false, children, ...props }: SelectApi) {
       if (o.type === 'Mesh') current.push(o)
     })
     if (enabled && current.some(o => !api.selected.includes(o))) {
-      api.select(state => [...new Set([...state, ...current])])
+      api.select(state => [...state, ...current])
     } else if (!enabled && current.some(o => api.selected.includes(o))) {
       api.select(state => state.filter(o => !current.includes(o)))
     }

--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -24,11 +24,14 @@ export function Select({ enabled = false, children, ...props }: SelectApi) {
   useEffect(() => {
     if (!api) return
     const current: THREE.Object3D<THREE.Event>[] = []
-    if (enabled) group.current.traverse((o) => {
+    group.current.traverse((o) => {
       if (o.type === 'Mesh') current.push(o)
     })
-    const changed = (current.length !== api.selected.length) ? true : !current.every(o => api.selected.includes(o))
-    if (changed) api.select(current)
+    if (enabled && current.some(o => !api.selected.includes(o))) {
+      api.select(state => [...new Set([...state, ...current])])
+    } else if (!enabled && current.some(o => api.selected.includes(o))) {
+      api.select(state => state.filter(o => !current.includes(o)))
+    }
   }, [enabled, children, api])
   return (
     <group ref={group} {...props}>

--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -22,20 +22,13 @@ export function Select({ enabled = false, children, ...props }: SelectApi) {
   const group = useRef<THREE.Group>(null!)
   const api = useContext(selectionContext)
   useEffect(() => {
-    if (api && enabled) {
-      let changed = false
-      const current: THREE.Object3D<THREE.Event>[] = []
-      group.current.traverse((o) => {
-        o.type === 'Mesh' && current.push(o)
-        if (api.selected.indexOf(o) === -1) changed = true
-      })
-      if (changed) {
-        api.select((state) => [...state, ...current])
-        return () => {
-          api.select((state) => state.filter((selected) => !current.includes(selected)))
-        }
-      }
-    }
+    if (!api) return
+    const current: THREE.Object3D<THREE.Event>[] = []
+    if (enabled) group.current.traverse((o) => {
+      if (o.type === 'Mesh') current.push(o)
+    })
+    const changed = (current.length !== api.selected.length) ? true : !current.every(o => api.selected.includes(o))
+    if (changed) api.select(current)
   }, [enabled, children, api])
   return (
     <group ref={group} {...props}>


### PR DESCRIPTION
See #236 for additional details

Would be great to hear your feedback on this. This code
```tsx
const changed = (current.length !== api.selected.length) ? true : !current.every(o => api.selected.includes(o))
```
is only correct if there are no duplicates in any of the two arrays (otherwise, they would have to be de-duped first) - but I believe that is the case here.