### PR TITLE
fix(Outline): dispose on unmount

### DIFF
--- a/src/effects/Outline.tsx
+++ b/src/effects/Outline.tsx
@@ -105,5 +105,11 @@ export const Outline = forwardRef(function Outline(
     }
   }, [api, effect.selection, invalidate])
 
+  useEffect(() => {
+    return () => {
+      effect.dispose()
+    }
+  }, [effect])
+
   return <primitive ref={forwardRef} object={effect} />
 })


### PR DESCRIPTION
Fixes a memory leak in `Outlines`.