### PR TITLE
fix(DoF): mask function

### DIFF
--- a/src/effects/DepthOfField.tsx
+++ b/src/effects/DepthOfField.tsx
@@ -58,8 +58,8 @@ export const DepthOfField = forwardRef(function DepthOfField(
     // Depth texture for depth picking with optional packing strategy
     if (depthTexture) effect.setDepthTexture(depthTexture.texture, depthTexture.packing as DepthPackingStrategies)
     // Temporary fix that restores DOF 6.21.3 behavior, everything since then lets shapes leak through the blur
-    const maskMaterial = (effect as any).maskPass.getFullscreenMaterial()
-    maskMaterial.maskFunction = MaskFunction.MULTIPLY_RGB_SET_ALPHA
+    const maskPass = (effect as any).maskPass
+    maskPass.maskFunction = MaskFunction.MULTIPLY_RGB_SET_ALPHA
     return effect
   }, [
     camera,


### PR DESCRIPTION
This should call the `DepthOfFieldEffect.maskFunction`  setter https://github.com/pmndrs/postprocessing/blob/v6.34.1/src/effects/DepthOfFieldEffect.js#L281

It's my first contribution to the postprocessing stack so please before merging double check that this does not cause any issue in other corner cases.

Fix #261 