### PR TITLE
update 'sRGBEncoding' to 'SRGBColorSpace' from 'three' module

### DIFF
--- a/src/effects/Texture.tsx
+++ b/src/effects/Texture.tsx
@@ -1,7 +1,7 @@
 import { TextureEffect } from 'postprocessing'
 import { Ref, forwardRef, useMemo, useLayoutEffect } from 'react'
 import { useLoader } from '@react-three/fiber'
-import { TextureLoader, sRGBEncoding, RepeatWrapping } from 'three'
+import { TextureLoader, SRGBColorSpace, RepeatWrapping } from 'three'
 
 type TextureProps = ConstructorParameters<typeof TextureEffect>[0] & {
   textureSrc: string
@@ -13,7 +13,7 @@ export const Texture = forwardRef<TextureEffect, TextureProps>(function Texture(
 ) {
   const t = useLoader(TextureLoader, textureSrc)
   useLayoutEffect(() => {
-    t.encoding = sRGBEncoding
+    t.encoding = SRGBColorSpace
     t.wrapS = t.wrapT = RepeatWrapping
   }, [t])
   const effect = useMemo(() => new TextureEffect({ ...props, texture: t || texture }), [props, t, texture])


### PR DESCRIPTION
With the last version of three the name of sRGBEncoding was renamed to SRGBColorSpace

"three": "^0.162.0"
