### PR TITLE
docs: update EffectComposer props

### DIFF
--- a/docs/effect-composer.mdx
+++ b/docs/effect-composer.mdx
@@ -9,7 +9,6 @@ The `EffectComposer` must wrap all your effects. It will manage them for you.
 <EffectComposer
   enabled?: boolean
   depthBuffer?: boolean
-  disableNormalPass?: boolean
   stencilBuffer?: boolean
   autoClear?: boolean
   multisampling?: number

--- a/docs/effect-composer.mdx
+++ b/docs/effect-composer.mdx
@@ -9,6 +9,7 @@ The `EffectComposer` must wrap all your effects. It will manage them for you.
 <EffectComposer
   enabled?: boolean
   depthBuffer?: boolean
+  enableNormalPass?: boolean
   stencilBuffer?: boolean
   autoClear?: boolean
   multisampling?: number


### PR DESCRIPTION
DisableNormalPass does not exist.
right ? 

I use "@react-three/postprocessing": "^2.16.2",

```
 "dependencies": {
    "@react-spring/three": "^9.7.3",
    "@react-three/drei": "^9.105.1",
    "@react-three/fiber": "^8.16.1",
    "@react-three/postprocessing": "^2.16.2",
    "gltfjsx": "^6.2.16",
    "maath": "^0.10.7",
    "next": "14.1.4",
    "prettier": "^3.2.5",
    "react": "^18",
    "react-dom": "^18",
    "three": "^0.163.0"
  },
```