### PR TITLE
docs: `Sepia` effect `intensity` type to `Number`

### DIFF
--- a/docs/effects/sepia.mdx
+++ b/docs/effects/sepia.mdx
@@ -24,5 +24,5 @@ return (
 
 | Name          | Type          | Default              | Description                        |
 | ------------- | ------------- | -------------------- | ---------------------------------- |
-| intensity     | Boolean       | 1                    | The intensity of the effect        |
+| intensity     | Number        | 1                    | The intensity of the effect        |
 | blendFunction | BlendFunction | BlendFunction.NORMAL | The blend function of this effect. |


### PR DESCRIPTION
The `Sepia`'s `intensity` prop should be a `Number` not a `Boolean` 👀

Just updated that in the docs 😄👌