### PR TITLE
fix: set composer size to current canvas output size

### DIFF
--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -1,5 +1,5 @@
 import type { TextureDataType } from 'three'
-import { HalfFloatType, NoToneMapping } from 'three'
+import { HalfFloatType, NoToneMapping, Vector2 } from 'three'
 import React, {
   forwardRef,
   useMemo,
@@ -47,6 +47,8 @@ export type EffectComposerProps = {
   camera?: THREE.Camera
   scene?: THREE.Scene
 }
+
+const glSize = new Vector2();
 
 const isConvolution = (effect: Effect): boolean =>
   (effect.getAttributes() & EffectAttribute.CONVOLUTION) === EffectAttribute.CONVOLUTION
@@ -114,7 +116,9 @@ export const EffectComposer = React.memo(
         resolutionScale,
       ])
 
-      useEffect(() => composer?.setSize(size.width, size.height), [composer, size])
+      gl.getSize(glSize);
+
+      useEffect(() => composer.setSize(glSize.width, glSize.height), [composer, glSize.width, glSize.height])
       useFrame(
         (_, delta) => {
           if (enabled) {


### PR DESCRIPTION
get current canvas output size and set composer size to this. Required to work with Drei's View.tsx, see https://github.com/pmndrs/react-postprocessing/issues/285