### PR TITLE
fix(SelectiveBloom): apply ignoreBackground and inverted props

### DIFF
--- a/src/effects/SelectiveBloom.tsx
+++ b/src/effects/SelectiveBloom.tsx
@@ -14,6 +14,8 @@ export type SelectiveBloomProps = BloomEffectOptions &
     lights: Object3D[] | ObjectRef[]
     selection: Object3D | Object3D[] | ObjectRef | ObjectRef[]
     selectionLayer: number
+    inverted: boolean
+    ignoreBackground: boolean
   }>
 
 const addLight = (light: Object3D, effect: SelectiveBloomEffect) => light.layers.enable(effect.selection.layer)
@@ -24,6 +26,8 @@ export const SelectiveBloom = forwardRef(function SelectiveBloom(
     selection = [],
     selectionLayer = 10,
     lights = [],
+    inverted = false,
+    ignoreBackground = false,
     luminanceThreshold,
     luminanceSmoothing,
     intensity,
@@ -43,8 +47,8 @@ export const SelectiveBloom = forwardRef(function SelectiveBloom(
   const invalidate = useThree((state) => state.invalidate)
   const { scene, camera } = useContext(EffectComposerContext)
   const effect = useMemo(
-    () =>
-      new SelectiveBloomEffect(scene, camera, {
+    () => {
+      const effect = new SelectiveBloomEffect(scene, camera, {
         blendFunction: BlendFunction.ADD,
         luminanceThreshold,
         luminanceSmoothing,
@@ -54,8 +58,12 @@ export const SelectiveBloom = forwardRef(function SelectiveBloom(
         kernelSize,
         mipmapBlur,
         ...props,
-      }),
-    [scene, camera, luminanceThreshold, luminanceSmoothing, intensity, width, height, kernelSize, mipmapBlur, props]
+      });
+      effect.inverted = inverted;
+      effect.ignoreBackground = ignoreBackground;
+      return effect;
+    },
+    [scene, camera, luminanceThreshold, luminanceSmoothing, intensity, width, height, kernelSize, mipmapBlur, inverted, ignoreBackground, props]
   )
 
   const api = useContext(selectionContext)


### PR DESCRIPTION
### Fix: Apply `ignoreBackground` and `inverted` Props in `SelectiveBloom`

Fixes #111 

#### Description of the Issue:

The `ignoreBackground` and `inverted` props of `SelectiveBloom` were not being applied, causing the selective bloom effect to work incorrectly, particularly when using an HDRI environment map. This issue is further detailed in [this GitHub issue](https://github.com/pmndrs/react-postprocessing/issues/111).

As shown in the images below:
- **Left:** Before the fix, the bloom effect is applied to bright areas of the background image and parts of the cube not selected for the bloom effect.
- **Right:** After the fix, the selective bloom effect is working as expected, with the background and cube affected correctly based on the props.

![Screenshot from 2024-10-04 15-42-39](https://github.com/user-attachments/assets/33a3b2e6-9ff8-4306-8f16-7403630437e9)

The suggested solution in issue #111 involved using emissive materials with values above the 0-1 RGB range and setting a high luminanceThreshold to control what glows. However, this does not work with HDRI images, as they contain areas of high luminosity that still get selected, even with a high luminanceThreshold like 100. This results in unintended glowing effects in the background, making ignoreBackground essential for proper selective blooming.

Codesandbox link to reproduce the issue https://codesandbox.io/p/sandbox/selective-bloom-props-issue-6fp8vm

#### Solution:
The `ignoreBackground` and `inverted` props are setters, but they were not passed as arguments in the constructor, resulting in them being ignored. This fix ensures that these props are now correctly applied, allowing the selective bloom effect to work as intended.

Please review and let me know if any additional changes are needed. Thank you!

#### Side note

The demo in the Storybook does not work as it uses the Environment component from an older version of @react-three/drei. In this version, the CDN hosting the sample preset HDR files is no longer active. Upgrading to "@react-three/drei": "^9.70.0" resolves this issue. But I haven't changed the version in this PR so the Storybook demo might break with fetch error.
