### PR TITLE
fix: correctly export type of ChromaticAberrationEffect

### DIFF
--- a/src/effects/ChromaticAberration.tsx
+++ b/src/effects/ChromaticAberration.tsx
@@ -1,5 +1,5 @@
 import { ChromaticAberrationEffect } from 'postprocessing'
 import { type EffectProps, wrapEffect } from '../util'
 
-export type ChromaticAberrationProps = EffectProps<typeof ChromaticAberrationEffect>
+export type ChromaticAberrationProps = EffectProps<ChromaticAberrationEffect>
 export const ChromaticAberration = wrapEffect(ChromaticAberrationEffect)


### PR DESCRIPTION
Correctly exporting ChromaticAberrationEffect as type 

closes issue 298