### PR TITLE
fix(ToneMapping): remove use of CONVOLUTION attribute

### DIFF
--- a/src/effects/ToneMapping.tsx
+++ b/src/effects/ToneMapping.tsx
@@ -1,56 +1,6 @@
-import { ToneMappingEffect, EffectAttribute } from 'postprocessing'
-import { EffectProps } from '../util'
-import { forwardRef, useEffect, useMemo } from 'react'
+import { ToneMappingEffect } from 'postprocessing'
+import { type EffectProps, wrapEffect } from '../util'
 
 export type ToneMappingProps = EffectProps<typeof ToneMappingEffect>
 
-export const ToneMapping = forwardRef<ToneMappingEffect, ToneMappingProps>(function ToneMapping(
-  {
-    blendFunction,
-    adaptive,
-    mode,
-    resolution,
-    maxLuminance,
-    whitePoint,
-    middleGrey,
-    minLuminance,
-    averageLuminance,
-    adaptationRate,
-    ...props
-  },
-  ref
-) {
-  const effect = useMemo(
-    () =>
-      new ToneMappingEffect({
-        blendFunction,
-        adaptive,
-        mode,
-        resolution,
-        maxLuminance,
-        whitePoint,
-        middleGrey,
-        minLuminance,
-        averageLuminance,
-        adaptationRate,
-      }),
-    [
-      blendFunction,
-      adaptive,
-      mode,
-      resolution,
-      maxLuminance,
-      whitePoint,
-      middleGrey,
-      minLuminance,
-      averageLuminance,
-      adaptationRate,
-    ]
-  )
-
-  useEffect(() => {
-    effect.dispose()
-  }, [effect])
-
-  return <primitive {...props} ref={ref} object={effect} attributes={EffectAttribute.CONVOLUTION} />
-})
+export const ToneMapping = wrapEffect(ToneMappingEffect)


### PR DESCRIPTION
Fixes #305 with a revert of #245. Convolution effects since lead to separate effect passes or severe performance ramifications when using tonemapping in projects, which is the end of a standard PBR workflow.