### PR TITLE
fix: narrow React peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,8 +89,8 @@
     "vitest": "^2.1.8"
   },
   "peerDependencies": {
-    "@react-three/fiber": ">=8.0",
-    "react": ">=18.0",
+    "@react-three/fiber": "^8.0",
+    "react": "^18.0",
     "three": ">= 0.138.0"
   }
 }


### PR DESCRIPTION
Narrows peer deps as React 19 is not backwards compatible. See #302.