### PR TITLE
chore: removed namespace imports using THREE

### DIFF
--- a/docs/effect-composer.mdx
+++ b/docs/effect-composer.mdx
@@ -17,8 +17,8 @@ The `EffectComposer` must wrap all your effects. It will manage them for you.
   /** For effects that support DepthDownsamplingPass */
   resolutionScale?: number
   renderPriority?: number
-  camera?: THREE.Camera
-  scene?: THREE.Scene
+  camera?: Camera
+  scene?: Scene
 >
 {/* your effects go here */}
 </EffectComposer>

--- a/docs/effects/autofocus.mdx
+++ b/docs/effects/autofocus.mdx
@@ -28,7 +28,7 @@ Ref-api:
 ```tsx
 type AutofocusApi = {
   dofRef: RefObject<DepthOfFieldEffect>
-  hitpoint: THREE.Vector3
+  hitpoint: Vector3
   update: (delta: number, updateTarget: boolean) => void
 }
 ```

--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -1,4 +1,4 @@
-import type { TextureDataType, Group } from 'three'
+import type { TextureDataType, Group, Camera, Scene } from 'three'
 import { HalfFloatType, NoToneMapping } from 'three'
 import {
   type JSX,
@@ -28,8 +28,8 @@ export const EffectComposerContext = /* @__PURE__ */ createContext<{
   composer: EffectComposerImpl
   normalPass: NormalPass | null
   downSamplingPass: DepthDownsamplingPass | null
-  camera: THREE.Camera
-  scene: THREE.Scene
+  camera: Camera
+  scene: Scene
   resolutionScale?: number
 }>(null!)
 
@@ -45,8 +45,8 @@ export type EffectComposerProps = {
   multisampling?: number
   frameBufferType?: TextureDataType
   renderPriority?: number
-  camera?: THREE.Camera
-  scene?: THREE.Scene
+  camera?: Camera
+  scene?: Scene
 }
 
 const isConvolution = (effect: Effect): boolean =>

--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -1,10 +1,10 @@
-import * as THREE from 'three'
 import React, { createContext, useState, useContext, useEffect, useRef, useMemo } from 'react'
 import { type ThreeElements } from '@react-three/fiber'
+import { Group, Object3D } from 'three'
 
 export type Api = {
-  selected: THREE.Object3D[]
-  select: React.Dispatch<React.SetStateAction<THREE.Object3D[]>>
+  selected: Object3D[]
+  select: React.Dispatch<React.SetStateAction<Object3D[]>>
   enabled: boolean
 }
 export type SelectApi = Omit<ThreeElements['group'], 'ref'> & {
@@ -14,18 +14,18 @@ export type SelectApi = Omit<ThreeElements['group'], 'ref'> & {
 export const selectionContext = /* @__PURE__ */ createContext<Api | null>(null)
 
 export function Selection({ children, enabled = true }: { enabled?: boolean; children: React.ReactNode }) {
-  const [selected, select] = useState<THREE.Object3D[]>([])
+  const [selected, select] = useState<Object3D[]>([])
   const value = useMemo(() => ({ selected, select, enabled }), [selected, select, enabled])
   return <selectionContext.Provider value={value}>{children}</selectionContext.Provider>
 }
 
 export function Select({ enabled = false, children, ...props }: SelectApi) {
-  const group = useRef<THREE.Group>(null!)
+  const group = useRef<Group>(null!)
   const api = useContext(selectionContext)
   useEffect(() => {
     if (api && enabled) {
       let changed = false
-      const current: THREE.Object3D[] = []
+      const current: Object3D[] = []
       group.current.traverse((o) => {
         o.type === 'Mesh' && current.push(o)
         if (api.selected.indexOf(o) === -1) changed = true

--- a/src/effects/ASCII.tsx
+++ b/src/effects/ASCII.tsx
@@ -82,7 +82,7 @@ class ASCIIEffect extends Effect {
   }
 
   /** Draws the characters on a Canvas and returns a texture */
-  public createCharactersTexture(characters: string, font: string, fontSize: number): THREE.Texture {
+  public createCharactersTexture(characters: string, font: string, fontSize: number): Texture {
     const canvas = document.createElement('canvas')
     const SIZE = 1024
     const MAX_PER_ROW = 16

--- a/src/effects/Autofocus.tsx
+++ b/src/effects/Autofocus.tsx
@@ -86,7 +86,7 @@ export const Autofocus = /* @__PURE__ */ forwardRef<AutofocusApi, AutofocusProps
       async (delta: number, updateTarget = true) => {
         // Update hitpoint
         if (target) {
-          hitpoint.set(...(target as [number, number, number]))
+          hitpoint.set(...(target as unknown as [number, number, number]))
         } else {
           const { x, y } = followMouse ? pointer : { x: 0, y: 0 }
           const hit = await getHit(x, y)

--- a/src/effects/Autofocus.tsx
+++ b/src/effects/Autofocus.tsx
@@ -1,4 +1,3 @@
-import * as THREE from 'three'
 import React, {
   useRef,
   useContext,
@@ -10,12 +9,13 @@ import React, {
   RefObject,
   useMemo,
 } from 'react'
-import { useThree, useFrame, createPortal, type Vector3 } from '@react-three/fiber'
+import { useThree, useFrame, createPortal } from '@react-three/fiber'
 import { CopyPass, DepthPickingPass, DepthOfFieldEffect } from 'postprocessing'
 import { easing } from 'maath'
 
 import { DepthOfField } from './DepthOfField.tsx'
 import { EffectComposerContext } from '../EffectComposer.tsx'
+import { Mesh, Vector3 } from 'three'
 
 export type AutofocusProps = React.ComponentProps<typeof DepthOfField> & {
   target?: Vector3
@@ -31,7 +31,7 @@ export type AutofocusProps = React.ComponentProps<typeof DepthOfField> & {
 
 export type AutofocusApi = {
   dofRef: RefObject<DepthOfFieldEffect | null>
-  hitpoint: THREE.Vector3
+  hitpoint: Vector3
   update: (delta: number, updateTarget: boolean) => void
 }
 
@@ -41,8 +41,8 @@ export const Autofocus = /* @__PURE__ */ forwardRef<AutofocusApi, AutofocusProps
     fref
   ) => {
     const dofRef = useRef<DepthOfFieldEffect>(null)
-    const hitpointRef = useRef<THREE.Mesh>(null)
-    const targetRef = useRef<THREE.Mesh>(null)
+    const hitpointRef = useRef<Mesh>(null)
+    const targetRef = useRef<Mesh>(null)
 
     const scene = useThree(({ scene }) => scene)
     const pointer = useThree(({ pointer }) => pointer)
@@ -67,9 +67,9 @@ export const Autofocus = /* @__PURE__ */ forwardRef<AutofocusApi, AutofocusProps
       }
     }, [depthPickingPass, copyPass])
 
-    const [hitpoint] = useState(() => new THREE.Vector3(0, 0, 0))
+    const [hitpoint] = useState(() => new Vector3(0, 0, 0))
 
-    const [ndc] = useState(() => new THREE.Vector3(0, 0, 0))
+    const [ndc] = useState(() => new Vector3(0, 0, 0))
     const getHit = useCallback(
       async (x: number, y: number) => {
         ndc.x = x

--- a/src/effects/LensFlare.tsx
+++ b/src/effects/LensFlare.tsx
@@ -1,7 +1,6 @@
 // Created by Anderson Mancini 2023
 // From https://github.com/ektogamat/R3F-Ultimate-Lens-Flare
 
-import * as THREE from 'three'
 import React, { useEffect, useState, useContext, useRef } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { BlendFunction, Effect } from 'postprocessing'
@@ -9,6 +8,7 @@ import { easing } from 'maath'
 
 import { EffectComposerContext } from '../EffectComposer.tsx'
 import { wrapEffect } from '../util.tsx'
+import { Color, Mesh, Texture, Uniform, Vector2, Vector3 } from 'three'
 
 const LensFlareShader = {
   fragmentShader: /* glsl */ `
@@ -406,9 +406,9 @@ type LensFlareEffectOptions = {
   /** The glare size */
   glareSize: number
   /** The position of the lens flare in 3d space */
-  lensPosition: THREE.Vector3
+  lensPosition: Vector3
   /** Effect resolution */
-  screenRes: THREE.Vector2
+  screenRes: Vector2
   /** The number of points for the star */
   starPoints: number
   /** The flare side */
@@ -421,10 +421,10 @@ type LensFlareEffectOptions = {
   animated: boolean
   /** Set the appearance to full anamorphic */
   anamorphic: boolean
-  /** Set the color gain for the lens flare. Must be a THREE.Color in RBG format */
-  colorGain: THREE.Color
+  /** Set the color gain for the lens flare. Must be a Color in RBG format */
+  colorGain: Color
   /** Texture to be used as color dirt for starburst effect */
-  lensDirtTexture: THREE.Texture | null
+  lensDirtTexture: Texture | null
   /** The halo scale */
   haloScale: number
   /** Option to enable/disable secondary ghosts */
@@ -463,26 +463,26 @@ export class LensFlareEffect extends Effect {
   }: LensFlareEffectOptions) {
     super('LensFlareEffect', LensFlareShader.fragmentShader, {
       blendFunction,
-      uniforms: new Map<string, THREE.Uniform>([
-        ['enabled', new THREE.Uniform(enabled)],
-        ['glareSize', new THREE.Uniform(glareSize)],
-        ['lensPosition', new THREE.Uniform(lensPosition)],
-        ['time', new THREE.Uniform(0)],
-        ['screenRes', new THREE.Uniform(screenRes)],
-        ['starPoints', new THREE.Uniform(starPoints)],
-        ['flareSize', new THREE.Uniform(flareSize)],
-        ['flareSpeed', new THREE.Uniform(flareSpeed)],
-        ['flareShape', new THREE.Uniform(flareShape)],
-        ['animated', new THREE.Uniform(animated)],
-        ['anamorphic', new THREE.Uniform(anamorphic)],
-        ['colorGain', new THREE.Uniform(colorGain)],
-        ['lensDirtTexture', new THREE.Uniform(lensDirtTexture)],
-        ['haloScale', new THREE.Uniform(haloScale)],
-        ['secondaryGhosts', new THREE.Uniform(secondaryGhosts)],
-        ['aditionalStreaks', new THREE.Uniform(aditionalStreaks)],
-        ['ghostScale', new THREE.Uniform(ghostScale)],
-        ['starBurst', new THREE.Uniform(starBurst)],
-        ['opacity', new THREE.Uniform(opacity)],
+      uniforms: new Map<string, Uniform>([
+        ['enabled', new Uniform(enabled)],
+        ['glareSize', new Uniform(glareSize)],
+        ['lensPosition', new Uniform(lensPosition)],
+        ['time', new Uniform(0)],
+        ['screenRes', new Uniform(screenRes)],
+        ['starPoints', new Uniform(starPoints)],
+        ['flareSize', new Uniform(flareSize)],
+        ['flareSpeed', new Uniform(flareSpeed)],
+        ['flareShape', new Uniform(flareShape)],
+        ['animated', new Uniform(animated)],
+        ['anamorphic', new Uniform(anamorphic)],
+        ['colorGain', new Uniform(colorGain)],
+        ['lensDirtTexture', new Uniform(lensDirtTexture)],
+        ['haloScale', new Uniform(haloScale)],
+        ['secondaryGhosts', new Uniform(secondaryGhosts)],
+        ['aditionalStreaks', new Uniform(aditionalStreaks)],
+        ['ghostScale', new Uniform(ghostScale)],
+        ['starBurst', new Uniform(starBurst)],
+        ['opacity', new Uniform(opacity)],
       ]),
     })
   }
@@ -497,7 +497,7 @@ export class LensFlareEffect extends Effect {
 
 type LensFlareProps = {
   /** Position of the effect */
-  lensPosition?: THREE.Vector3
+  lensPosition?: Vector3
   /** The time that it takes to fade the occlusion */
   smoothTime?: number
 } & Partial<LensFlareEffectOptions>
@@ -510,15 +510,15 @@ export const LensFlare = ({
   blendFunction = BlendFunction.NORMAL,
   enabled = true,
   glareSize = 0.2,
-  lensPosition = new THREE.Vector3(-25, 6, -60),
-  screenRes = new THREE.Vector2(0, 0),
+  lensPosition = new Vector3(-25, 6, -60),
+  screenRes = new Vector2(0, 0),
   starPoints = 6,
   flareSize = 0.01,
   flareSpeed = 0.01,
   flareShape = 0.01,
   animated = true,
   anamorphic = false,
-  colorGain = new THREE.Color(20, 20, 20),
+  colorGain = new Color(20, 20, 20),
   lensDirtTexture = null,
   haloScale = 0.5,
   secondaryGhosts = true,
@@ -530,8 +530,8 @@ export const LensFlare = ({
   const viewport = useThree(({ viewport }) => viewport)
   const raycaster = useThree(({ raycaster }) => raycaster)
   const { scene, camera } = useContext(EffectComposerContext)
-  const [raycasterPos] = useState(() => new THREE.Vector2())
-  const [projectedPosition] = useState(() => new THREE.Vector3())
+  const [raycasterPos] = useState(() => new Vector2())
+  const [projectedPosition] = useState(() => new Vector3())
 
   const ref = useRef<LensFlareEffect>(null)
 
@@ -557,7 +557,7 @@ export const LensFlare = ({
     if (object) {
       if (object.userData?.lensflare === 'no-occlusion') {
         target = 0
-      } else if (object instanceof THREE.Mesh) {
+      } else if (object instanceof Mesh) {
         if (object.material.uniforms?._transmission?.value > 0.2) {
           //Check for MeshTransmissionMaterial
           target = 0.2

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,6 +1,5 @@
 import React, { RefObject } from 'react'
-import { Vector2 } from 'three'
-import * as THREE from 'three'
+import { Vector2, Vector2Tuple } from 'three'
 import { type ReactThreeFiber, type ThreeElement, extend, useThree } from '@react-three/fiber'
 import type { Effect, Pass, BlendFunction } from 'postprocessing'
 
@@ -45,11 +44,11 @@ export const wrapEffect = <T extends EffectConstructor>(effect: T, defaults?: Ef
     )
   }
 
-export const useVector2 = (props: Record<string, unknown>, key: string): THREE.Vector2 => {
+export const useVector2 = (props: Record<string, unknown>, key: string): Vector2 => {
   const value = props[key] as ReactThreeFiber.Vector2 | undefined
   return React.useMemo(() => {
-    if (typeof value === 'number') return new THREE.Vector2(value, value)
-    else if (value) return new THREE.Vector2(...(value as THREE.Vector2Tuple))
-    else return new THREE.Vector2()
+    if (typeof value === 'number') return new Vector2(value, value)
+    else if (value) return new Vector2(...(value as Vector2Tuple))
+    else return new Vector2()
   }, [value])
 }


### PR DESCRIPTION
In my builds I was getting some errors where `import * as THREE` was missing.
To address this I've removed all namespace imports  (`import *`) and replaced with individual imports. My understanding is this will also potentially help with tree shaking and just feels cleaner.

```
./node_modules/.pnpm/@react-three+postprocessing@3.0.0-rc.0_@react-three+fiber@9.0.0-rc.2_@types+react@19.0.3_imme_gv7lyvaps33qn6z24hdlvw36t4/node_modules/@react-three/postprocessing/src/EffectComposer.tsx:31:11
Type error: Cannot find namespace 'THREE'.
  29 |   normalPass: NormalPass | null
  30 |   downSamplingPass: DepthDownsamplingPass | null
> 31 |   camera: THREE.Camera
     |           ^
  32 |   scene: THREE.Scene
  33 |   resolutionScale?: number
  34 | }>(null!)
Static worker exited with code: 1 and signal: null
 ELIFECYCLE  Command failed with exit code 1.
 ELIFECYCLE  Command failed with exit code 1.
Error: Command "pnpm vercel:build" exited with 1
```