### PR TITLE
fix: include dist folder in release artifacts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 node_modules/
 coverage/
 example/
-dist/
 build/
 Thumbs.db
 ehthumbs.db


### PR DESCRIPTION
Fixes #324. Removes `dist` from ignored directories.