### PR TITLE
fix: create EffectPasses by groupInstance.children

### DIFF
--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -138,6 +138,7 @@ export const EffectComposer = /* @__PURE__ */ memo(
           const children = groupInstance.children
 
           for (let i = 0; i < children.length; i++) {
+            if (children[i] === undefined) continue
             const child = children[i].object
 
             if (child instanceof Effect) {


### PR DESCRIPTION
This pull request includes a small change to the `EffectComposer` component in the `src/EffectComposer.tsx` file. The change adds a check to skip over undefined children in a loop.

* [`src/EffectComposer.tsx`](diffhunk://#diff-3741251b23ab998f6fa80f88c855672c0e1f37909117f7c763fee0f62fb55b11R141): Added a condition to continue the loop if a child element is undefined.

![screen](https://github.com/user-attachments/assets/79f1651a-925b-4793-856b-0c8828c8841f)

maybe broken by this change

https://github.com/pmndrs/react-postprocessing/compare/v2.19.1...v3.0.0#diff-3741251b23ab998f6fa80f88c855672c0e1f37909117f7c763fee0f62fb55b11L142-R141
