### PR TITLE
[fix] Maximum update depth exceeded error

### DIFF
--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -37,7 +37,7 @@ export function Select({ enabled = false, children, ...props }: SelectApi) {
         }
       }
     }
-  }, [enabled, children, api])
+  }, [enabled, children])
   return (
     <group ref={group} {...props}>
       {children}


### PR DESCRIPTION
I met https://github.com/pmndrs/react-postprocessing/issues/330 issue.

Simply deleting `api` from useEffect hook, I found that it stopped the infinite loop.

But I'm afraid it is okay to remove `api` for interest in useEffect hook. ;)