### PR TITLE
docs: Update Custom Effects docs for React 19

### DIFF
--- a/docs/effects/custom-effects.mdx
+++ b/docs/effects/custom-effects.mdx
@@ -42,8 +42,8 @@ class MyCustomEffectImpl extends Effect {
 }
 
 // Effect component
-export const MyCustomEffect = forwardRef(({ param }, ref) => {
+export const MyCustomEffect = ({ ref, param }) => {
   const effect = useMemo(() => new MyCustomEffectImpl(param), [param])
   return <primitive ref={ref} object={effect} dispose={null} />
-})
+}
 ```


### PR DESCRIPTION
Small update to the docs to reflect the recent changes from React 19 regarding refs

Let me know if you'd want to specify an example for both React < 19.0.0 and React >= 19.0.0, I believe most new devs joining will be on the more recent version though