### PR TITLE
fix: Fix ref as prop causing circular reference in useMemo in React 19

### DIFF
--- a/src/util.tsx
+++ b/src/util.tsx
@@ -21,6 +21,7 @@ const components = new WeakMap<EffectConstructor, React.ExoticComponent<any> | s
 export const wrapEffect = <T extends EffectConstructor>(effect: T, defaults?: EffectProps<T>) =>
   /* @__PURE__ */ function Effect({ blendFunction = defaults?.blendFunction, opacity = defaults?.opacity, ...props }) {
     let Component = components.get(effect)
+    const { ref, ...params } = props
     if (!Component) {
       const key = `@react-three/postprocessing/${effect.name}-${i++}`
       extend({ [key]: effect })
@@ -29,9 +30,9 @@ export const wrapEffect = <T extends EffectConstructor>(effect: T, defaults?: Ef
 
     const camera = useThree((state) => state.camera)
     const args = React.useMemo(
-      () => [...(defaults?.args ?? []), ...(props.args ?? [{ ...defaults, ...props }])],
+      () => [...(defaults?.args ?? []), ...(params.args ?? [{ ...defaults, ...params }])],
       // eslint-disable-next-line react-hooks/exhaustive-deps
-      [JSON.stringify(props)]
+      [JSON.stringify(params)]
     )
 
     return (


### PR DESCRIPTION
## Description
Starting React 19, refs passed as props

This caused the `wrapEffect` function to not work anymore as the ref ended up being passed accidentally as a dependency of `useMemo` causing a circular reference issue.

Not sure what's the overall strategy regarding backwards compatibility with React 18.x, and whether any future version of @react-three dependencies plan on supporting older versions of React. Let me know / feel free to adjust this PR based on that.

## How to reproduce the issue
- Be on React 19 + React Three Fiber v9
- Create a scene using this package with an effect composer and an effect that depends on `wrapEffect` or using a custom effect with `wrapEffect`
- Pass a ref to a custom effect or to any effect bundled in the package that rely on `wrapEffect` -> you should see the circular reference issue and the scene will not render anymore

## How was it tested
Forked the repo and tested the fix for this function by moving it into my own repo with my own custom effect example

Note: As this package still relies on yarn and all my project are on pnpm, I was not able to do further testing building the package locally and linking it. 

## Issues this addresses

Fixes:
- #334
- #333 
- #332 