### PR TITLE
docs: update tone mapping examples and props table

### DIFF
--- a/docs/effects/tone-mapping.mdx
+++ b/docs/effects/tone-mapping.mdx
@@ -7,6 +7,19 @@ A tone mapping effect.
 
 ```jsx
 import { ToneMapping } from '@react-three/postprocessing'
+import { ToneMappingMode } from 'postprocessing'
+
+return (
+  <ToneMapping
+    mode={ToneMappingMode.ACES_FILMIC} // tone mapping mode
+  />
+)
+```
+
+OR
+
+```jsx
+import { ToneMapping } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
 
 return (
@@ -28,13 +41,14 @@ return (
 
 ## Props
 
-| Name             | Type          | Default | Description                                                         |
-| ---------------- | ------------- | ------- | ------------------------------------------------------------------- |
-| resolution       | Number        | 256     | The resolution of the luminance texture. Must be a power of two.    |
-| adaptive         | boolean       | true    | Toggle adaptive luminance map usage                                 |
-| blendFunction    | BlendFunction |         | The blend function of this effect.                                  |
-| middleGrey       | Number        | 0.6     | The middle grey factor.                                             |
-| maxLuminance     | Number        | 16      | Maximum luminance                                                   |
-| minLuminance     | Number        | 0.01    | The minimum luminance. Prevents very high exposure in dark scenes.  |
-| averageLuminance | Number        | 1       | The average luminance. Used for the non-adaptive Reinhard operator. |
-| adaptationRate   | Number        | 1       | The luminance adaptation rate.                                      |
+| Name             | Type            | Default | Description                                                         |
+| ---------------- | --------------- | ------- | ------------------------------------------------------------------- |
+| mode             | ToneMappingMode |         | The tone mapping algorithm                                          |
+| resolution       | Number          | 256     | The resolution of the luminance texture. Must be a power of two.    |
+| adaptive         | boolean         | true    | Toggle adaptive luminance map usage                                 |
+| blendFunction    | BlendFunction   |         | The blend function of this effect.                                  |
+| middleGrey       | Number          | 0.6     | The middle grey factor.                                             |
+| maxLuminance     | Number          | 16      | Maximum luminance                                                   |
+| minLuminance     | Number          | 0.01    | The minimum luminance. Prevents very high exposure in dark scenes.  |
+| averageLuminance | Number          | 1       | The average luminance. Used for the non-adaptive Reinhard operator. |
+| adaptationRate   | Number          | 1       | The luminance adaptation rate.                                      |


### PR DESCRIPTION
This PR adds documentation for the `mode` prop in the ToneMapping effect, which was previously undocumented.

Changes
- Added example showing simple usage with mode prop set to `ToneMappingMode.ACES_FILMIC`
- Separated examples with 'OR' to show two usage patterns
- Added `mode` prop to the Props table