### PR TITLE
Decrease default multisampling to 2

### DIFF
--- a/src/EffectComposer.tsx
+++ b/src/EffectComposer.tsx
@@ -65,7 +65,7 @@ export const EffectComposer = /* @__PURE__ */ memo(
         depthBuffer,
         enableNormalPass,
         stencilBuffer,
-        multisampling = 8,
+        multisampling = 2,
         frameBufferType = HalfFloatType,
       },
       ref


### PR DESCRIPTION
I propose to decrease default multisampling value to 2. Even on the modern GPU such high value as 8 is too much, especially if the target resolution is 2k or 4k. Modern displays have a higher pixel density than before so antialiasing is not needed as much as before. Also x8 antialiasing was an overkill even on older displays, x2 was fine and x4 was just right in my opinion.
Having x8 antialiasing by default just cause spikes on the framerate and loading GPU without notifying the client, it is a noticeable performance issue that may spend a lot of time to investigate for developers.
Me personally faced that issue twice. When I faced the framerate spikes for the second time even having the knowledge on the bottom of my head I naturally blamed postprocessing filters itself, not the composer, the issue was annoying but not critical so when I finally found the root cause I have a thought that I might be not alone. So that's the reason why I created this PR.