### PR TITLE
fix: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "type": "git",
     "url": "git+https://github.com/pmndrs/react-postprocessing.git"
   },
+  "bugs": {
+    "url": "https://github.com/pmndrs/react-postprocessing/issues"
+  },
+  "homepage": "https://github.com/pmndrs/react-postprocessing#readme",
   "scripts": {
     "build": "rimraf dist && vite build && tsc",
     "eslint": "eslint . --fix --ext=js,ts,jsx,tsx",


### PR DESCRIPTION
Adds the missing npm package metadata for `@react-three/postprocessing` so the published package can expose a homepage and issue tracker link.

Changes:
- add `bugs.url` pointing to the GitHub issues page
- add `homepage` pointing to the repository README

Verification:
- `node -e "const p=require('./package.json'); if(!p.bugs?.url||!p.homepage) process.exit(1); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,bugs:p.bugs,homepage:p.homepage},null,2))"`
- `npm pack --dry-run --json --ignore-scripts`