### PR TITLE
fix(ChromaticAberration): coerce offset prop to Vector2

### DIFF
--- a/src/effects/ChromaticAberration.test.tsx
+++ b/src/effects/ChromaticAberration.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { describe, it, expect } from 'vitest'
+import { extend, createRoot, act } from '@react-three/fiber'
+import { ChromaticAberrationEffect } from 'postprocessing'
+import { EffectComposer } from '../EffectComposer'
+import { ChromaticAberration } from './ChromaticAberration'
+
+// Let React know that we'll be testing effectful components
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean
+}
+global.IS_REACT_ACT_ENVIRONMENT = true
+
+// Create virtual R3F root for testing
+extend(THREE as any)
+const root = createRoot({
+  style: {} as CSSStyleDeclaration,
+  addEventListener: (() => {}) as any,
+  removeEventListener: (() => {}) as any,
+  width: 1280,
+  height: 800,
+  clientWidth: 1280,
+  clientHeight: 800,
+  getContext: (() =>
+    new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          switch (prop) {
+            case 'getParameter':
+              return () => 'WebGL 2' // GL_VERSION
+            case 'getExtension':
+              return () => ({}) // EXT_blend_minmax
+            case 'getContextAttributes':
+              return () => ({ alpha: true })
+            case 'getShaderPrecisionFormat':
+              return () => ({ rangeMin: 1, rangeMax: 1, precision: 1 })
+            default:
+              return () => {}
+          }
+        },
+      }
+    )) as any,
+} satisfies Partial<HTMLCanvasElement> as HTMLCanvasElement)
+root.configure({ frameloop: 'never' })
+
+describe('ChromaticAberration', () => {
+  it('coerces a tuple offset to a Vector2 so the imperative API works', async () => {
+    const ref = React.createRef<ChromaticAberrationEffect>()
+
+    await act(async () =>
+      root.render(
+        <EffectComposer>
+          <ChromaticAberration ref={ref} offset={[0.001, 0.0005]} />
+        </EffectComposer>
+      )
+    )
+
+    const effect = ref.current!
+    expect(effect).toBeInstanceOf(ChromaticAberrationEffect)
+    expect(effect.offset).toBeInstanceOf(THREE.Vector2)
+    expect(effect.offset.x).toBe(0.001)
+    expect(effect.offset.y).toBe(0.0005)
+    // The pattern from the docs/examples that used to throw "offset.set is not a function"
+    expect(() => effect.offset.set(0.002, 0.001)).not.toThrow()
+    expect(effect.offset.x).toBe(0.002)
+  })
+
+  it('keeps the effect default when no offset is passed', async () => {
+    const ref = React.createRef<ChromaticAberrationEffect>()
+
+    await act(async () =>
+      root.render(
+        <EffectComposer>
+          <ChromaticAberration ref={ref} />
+        </EffectComposer>
+      )
+    )
+
+    const effect = ref.current!
+    const fallback = new ChromaticAberrationEffect()
+    expect(effect.offset).toBeInstanceOf(THREE.Vector2)
+    expect(effect.offset.x).toBe(fallback.offset.x)
+    expect(effect.offset.y).toBe(fallback.offset.y)
+  })
+})

--- a/src/effects/ChromaticAberration.tsx
+++ b/src/effects/ChromaticAberration.tsx
@@ -1,5 +1,22 @@
 import { ChromaticAberrationEffect } from 'postprocessing'
-import { type EffectProps, wrapEffect } from '../util'
+import { Ref, forwardRef } from 'react'
+import { type ReactThreeFiber } from '@react-three/fiber'
+import { type EffectProps, useVector2, wrapEffect } from '../util'
 
-export type ChromaticAberrationProps = EffectProps<typeof ChromaticAberrationEffect>
-export const ChromaticAberration = /* @__PURE__ */ wrapEffect(ChromaticAberrationEffect)
+export type ChromaticAberrationProps = EffectProps<typeof ChromaticAberrationEffect> & {
+  offset?: ReactThreeFiber.Vector2
+}
+
+const ChromaticAberrationImpl = /* @__PURE__ */ wrapEffect(ChromaticAberrationEffect)
+
+export const ChromaticAberration = /* @__PURE__ */ forwardRef<ChromaticAberrationEffect, ChromaticAberrationProps>(
+  function ChromaticAberration(props: ChromaticAberrationProps, ref: Ref<ChromaticAberrationEffect>) {
+    // Coerce number/tuple offsets to a Vector2 before they reach the effect
+    // constructor, which stores whatever it is given into a Uniform (same
+    // pattern as Glitch.tsx). Without this, `offset={[x, y]}` type-checks
+    // but leaves `effect.offset` as a plain array, so the imperative API
+    // (`ref.current.offset.set(...)`) throws.
+    const offset = useVector2(props, 'offset')
+    return <ChromaticAberrationImpl ref={ref} {...props} offset={props.offset !== undefined ? offset : undefined} />
+  }
+)


### PR DESCRIPTION
Fixes #348.

Routes `offset` through the existing `useVector2` helper before it reaches the effect constructor, mirroring what `Glitch` already does. When `offset` isn't passed, the effect's own default `Vector2(0.001, 0.0005)` is left untouched.

- Thin `forwardRef` wrapper around the existing `wrapEffect` component, so `blendFunction`/`opacity` handling is unchanged
- Two regression tests using the same virtual-root harness as `EffectComposer.test.tsx`: tuple coercion (fails on master), default preservation
- `vitest` 3 passed, `eslint` clean, `yarn build` clean
