### PR TITLE
fix(Selection): stop Select's effect from depending on its own write

### DIFF
--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -39,29 +39,45 @@ export function Select({ enabled = false, children, ...props }: SelectApi) {
   const group = useRef<Group>(null!)
   // Stable setter, unlike the context value - avoids retriggering off our own write.
   const select = use(selectionContext)?.select
+  // What this Select currently has claimed in `selected`, so a re-run
+  // diffs against that instead of unconditionally clearing and re-adding through effect cleanup.
+  const claimed = useRef<Object3D[]>([])
 
   useEffect(() => {
-    if (!select || !enabled) return
+    if (!select) return
 
     const current: Object3D[] = []
-    group.current.traverse((o) => {
-      if (isSelectable(o)) current.push(o)
-    })
-
-    // Diff against latest state inside the updater; bail with the same
-    // reference when unchanged so React can skip the re-render.
-    select((prev) => {
-      const additions = current.filter((o) => !prev.includes(o))
-      return additions.length ? [...prev, ...additions] : prev
-    })
-
-    return () => {
-      select((prev) => {
-        const next = prev.filter((o) => !current.includes(o))
-        return next.length !== prev.length ? next : prev
+    if (enabled) {
+      group.current.traverse((o) => {
+        if (isSelectable(o)) current.push(o)
       })
     }
+
+    const previouslyClaimed = claimed.current
+    claimed.current = current
+
+    select((prev) => {
+      // Add anything missing from live state - covers both the normal
+      // case and re-asserting a claim some other Select's own update
+      // dropped in the meantime (nested Selects share objects). Only
+      // remove what this Select itself is no longer claiming.
+      const toAdd = current.filter((o) => !prev.includes(o))
+      const toRemove = previouslyClaimed.filter((o) => !current.includes(o) && prev.includes(o))
+      if (!toAdd.length && !toRemove.length) return prev
+      const kept = toRemove.length ? prev.filter((o) => !toRemove.includes(o)) : prev
+      return toAdd.length ? [...kept, ...toAdd] : kept
+    })
   }, [enabled, children, select])
+
+  // Only for unmount - a separate effect so it doesn't fire on every
+  // enabled/children change like the diffing effect above does.
+  useEffect(() => {
+    return () => {
+      if (!select || !claimed.current.length) return
+      const stillClaimed = claimed.current
+      select((prev) => prev.filter((o) => !stillClaimed.includes(o)))
+    }
+  }, [select])
 
   return (
     <group ref={group} {...props}>

--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -1,7 +1,7 @@
 import { type ThreeElements } from '@react-three/fiber'
 import {
   createContext,
-  useContext,
+  use,
   useEffect,
   useMemo,
   useRef,
@@ -10,7 +10,7 @@ import {
   type ReactNode,
   type SetStateAction,
 } from 'react'
-import { type Group, type Object3D } from 'three'
+import { type Group, type Line, type Mesh, type Object3D, type Points } from 'three'
 
 export type Api = {
   selected: Object3D[]
@@ -29,25 +29,40 @@ export function Selection({ children, enabled = true }: { enabled?: boolean; chi
   return <selectionContext.Provider value={value}>{children}</selectionContext.Provider>
 }
 
+// `.type` is a free-form string; these flags cover Mesh/Line/Points subclasses too.
+function isSelectable(object: Object3D): boolean {
+  const o = object as Partial<Mesh & Line & Points>
+  return !!(o.isMesh || o.isLine || o.isPoints)
+}
+
 export function Select({ enabled = false, children, ...props }: SelectApi) {
   const group = useRef<Group>(null!)
-  const api = useContext(selectionContext)
+  // Stable setter, unlike the context value - avoids retriggering off our own write.
+  const select = use(selectionContext)?.select
+
   useEffect(() => {
-    if (api && enabled) {
-      let changed = false
-      const current: Object3D[] = []
-      group.current.traverse((o) => {
-        o.type === 'Mesh' && current.push(o)
-        if (api.selected.indexOf(o) === -1) changed = true
+    if (!select || !enabled) return
+
+    const current: Object3D[] = []
+    group.current.traverse((o) => {
+      if (isSelectable(o)) current.push(o)
+    })
+
+    // Diff against latest state inside the updater; bail with the same
+    // reference when unchanged so React can skip the re-render.
+    select((prev) => {
+      const additions = current.filter((o) => !prev.includes(o))
+      return additions.length ? [...prev, ...additions] : prev
+    })
+
+    return () => {
+      select((prev) => {
+        const next = prev.filter((o) => !current.includes(o))
+        return next.length !== prev.length ? next : prev
       })
-      if (changed) {
-        api.select((state) => [...state, ...current])
-        return () => {
-          api.select((state) => state.filter((selected) => !current.includes(selected)))
-        }
-      }
     }
-  }, [enabled, children, api])
+  }, [enabled, children, select])
+
   return (
     <group ref={group} {...props}>
       {children}

--- a/src/Selection.tsx
+++ b/src/Selection.tsx
@@ -29,7 +29,7 @@ export function Selection({ children, enabled = true }: { enabled?: boolean; chi
   return <selectionContext.Provider value={value}>{children}</selectionContext.Provider>
 }
 
-// `.type` is a free-form string; these flags cover Mesh/Line/Points subclasses too.
+// Covers Mesh/Line/Points subclasses too, unlike `.type`.
 function isSelectable(object: Object3D): boolean {
   const o = object as Partial<Mesh & Line & Points>
   return !!(o.isMesh || o.isLine || o.isPoints)
@@ -37,10 +37,8 @@ function isSelectable(object: Object3D): boolean {
 
 export function Select({ enabled = false, children, ...props }: SelectApi) {
   const group = useRef<Group>(null!)
-  // Stable setter, unlike the context value - avoids retriggering off our own write.
+  // Stable, unlike the context value - avoids retriggering off our own write.
   const select = use(selectionContext)?.select
-  // What this Select currently has claimed in `selected`, so a re-run
-  // diffs against that instead of unconditionally clearing and re-adding through effect cleanup.
   const claimed = useRef<Object3D[]>([])
 
   useEffect(() => {
@@ -57,25 +55,26 @@ export function Select({ enabled = false, children, ...props }: SelectApi) {
     claimed.current = current
 
     select((prev) => {
-      // Add anything missing from live state - covers both the normal
-      // case and re-asserting a claim some other Select's own update
-      // dropped in the meantime (nested Selects share objects). Only
-      // remove what this Select itself is no longer claiming.
-      const toAdd = current.filter((o) => !prev.includes(o))
-      const toRemove = previouslyClaimed.filter((o) => !current.includes(o) && prev.includes(o))
+      const prevSet = new Set(prev)
+      const currentSet = new Set(current)
+      const toAdd = current.filter((o) => !prevSet.has(o))
+      const toRemove = previouslyClaimed.filter((o) => !currentSet.has(o) && prevSet.has(o))
       if (!toAdd.length && !toRemove.length) return prev
-      const kept = toRemove.length ? prev.filter((o) => !toRemove.includes(o)) : prev
+      const toRemoveSet = toRemove.length ? new Set(toRemove) : null
+      const kept = toRemoveSet ? prev.filter((o) => !toRemoveSet.has(o)) : prev
       return toAdd.length ? [...kept, ...toAdd] : kept
     })
   }, [enabled, children, select])
 
-  // Only for unmount - a separate effect so it doesn't fire on every
-  // enabled/children change like the diffing effect above does.
+  // Separate from the effect above so unmount cleanup doesn't fire on every enabled/children change.
   useEffect(() => {
     return () => {
       if (!select || !claimed.current.length) return
-      const stillClaimed = claimed.current
-      select((prev) => prev.filter((o) => !stillClaimed.includes(o)))
+      const stillClaimed = new Set(claimed.current)
+      select((prev) => {
+        const next = prev.filter((o) => !stillClaimed.has(o))
+        return next.length !== prev.length ? next : prev
+      })
     }
   }, [select])
 

--- a/src/tests/Selection.test.tsx
+++ b/src/tests/Selection.test.tsx
@@ -268,4 +268,57 @@ describe('Selection/Select', () => {
 
     expect(new Set(refs).size).toBe(1)
   })
+
+  it('a cleanup updater returns the same reference when nothing is left for it to remove', async () => {
+    const meshRef = React.createRef<THREE.Mesh>()
+    const updaters: Array<(prev: THREE.Object3D[]) => THREE.Object3D[]> = []
+
+    // React batches both nested Selects' cleanup calls into a single
+    // re-render regardless of this bail-out (the net change from mount to
+    // unmount is real), so the optimization isn't observable through
+    // rendering alone. Capture the raw updater functions instead and
+    // replay them directly to verify the second one bails.
+    function CapturingSelection({ children }: { children: React.ReactNode }) {
+      const [selected, setSelected] = React.useState<THREE.Object3D[]>([])
+      const select = React.useCallback((updater: React.SetStateAction<THREE.Object3D[]>) => {
+        if (typeof updater === 'function') updaters.push(updater as (prev: THREE.Object3D[]) => THREE.Object3D[])
+        setSelected(updater)
+      }, [])
+      const value = React.useMemo(() => ({ selected, select, enabled: true }), [selected, select])
+      return <selectionContext.Provider value={value}>{children}</selectionContext.Provider>
+    }
+
+    const render = (mounted: boolean) =>
+      root.render(
+        <CapturingSelection>
+          {mounted && (
+            <Select enabled>
+              <Select enabled>
+                <mesh ref={meshRef}>
+                  <boxGeometry />
+                  <meshBasicMaterial />
+                </mesh>
+              </Select>
+            </Select>
+          )}
+        </CapturingSelection>
+      )
+
+    await React.act(async () => render(true))
+    await flush()
+    await flush()
+    await flush()
+
+    const mesh = meshRef.current!
+    updaters.length = 0
+    await React.act(async () => render(false))
+    await flush()
+    await flush()
+    await flush()
+
+    expect(updaters).toHaveLength(2)
+    const afterFirst = updaters[0]([mesh])
+    const afterSecond = updaters[1](afterFirst)
+    expect(afterSecond).toBe(afterFirst)
+  })
 })

--- a/src/tests/Selection.test.tsx
+++ b/src/tests/Selection.test.tsx
@@ -107,9 +107,7 @@ describe('Selection/Select', () => {
     await React.act(async () => render(true))
     await flush()
     await flush()
-    expect(snapshots[snapshots.length - 1]).toEqual(
-      expect.arrayContaining([meshARef.current, meshBRef.current])
-    )
+    expect(snapshots[snapshots.length - 1]).toEqual(expect.arrayContaining([meshARef.current, meshBRef.current]))
 
     await React.act(async () => render(false))
     await flush()
@@ -228,5 +226,46 @@ describe('Selection/Select', () => {
     // The inner Select's own cleanup drops its claim, but the mesh never
     // left the outer Select's subtree - its own traversal still finds it.
     expect(snapshots[snapshots.length - 1]).toContain(meshRef.current)
+  })
+
+  it('does not change the selected array reference on a re-render where children only changes identity', async () => {
+    const refs: THREE.Object3D[][] = []
+    const meshRef = React.createRef<THREE.Mesh>()
+
+    function CaptureRef() {
+      const api = React.useContext(selectionContext)
+      React.useEffect(() => {
+        if (api) refs.push(api.selected)
+      })
+      return null
+    }
+
+    // A fresh JSX tree every call, like a parent re-rendering for an
+    // unrelated reason - Select's own `children` prop is a new reference
+    // each time even though the underlying mesh never changes.
+    const render = () =>
+      root.render(
+        <Selection>
+          <CaptureRef />
+          <Select enabled>
+            <mesh ref={meshRef}>
+              <boxGeometry />
+              <meshBasicMaterial />
+            </mesh>
+          </Select>
+        </Selection>
+      )
+
+    await React.act(async () => render())
+    await flush()
+    await flush()
+
+    refs.length = 0
+    for (let i = 0; i < 5; i++) {
+      await React.act(async () => render())
+      await flush()
+    }
+
+    expect(new Set(refs).size).toBe(1)
   })
 })

--- a/src/tests/Selection.test.tsx
+++ b/src/tests/Selection.test.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react'
+import * as THREE from 'three'
+import { afterEach, describe, expect, it } from 'vitest'
+import { Select, Selection, selectionContext } from '../Selection'
+import { flush, root } from './test-utils'
+
+afterEach(async () => {
+  await React.act(async () => {
+    root.render(null)
+  })
+})
+
+function Capture({ onSnapshot }: { onSnapshot: (selected: THREE.Object3D[]) => void }) {
+  const api = React.useContext(selectionContext)
+  React.useEffect(() => {
+    onSnapshot(api?.selected ?? [])
+  })
+  return null
+}
+
+describe('Selection/Select', () => {
+  it('settles to a stable selected array without looping', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const meshRef = React.createRef<THREE.Mesh>()
+
+    await React.act(async () =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          <Select enabled>
+            <mesh ref={meshRef}>
+              <boxGeometry />
+              <meshBasicMaterial />
+            </mesh>
+          </Select>
+        </Selection>
+      )
+    )
+    await flush()
+    await flush()
+
+    // Exactly one render for the initial (empty) commit, one for the
+    // single necessary addition - the original bug kept re-triggering
+    // itself, so this would grow unbounded (and eventually throw) instead
+    // of stopping at 2.
+    expect(snapshots).toEqual([[], [meshRef.current]])
+  })
+
+  it('selects a Line and a Points object, not just Mesh', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const lineRef = React.createRef<THREE.Line>()
+    const pointsRef = React.createRef<THREE.Points>()
+
+    await React.act(async () =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          <Select enabled>
+            <threeLine ref={lineRef}>
+              <bufferGeometry />
+              <lineBasicMaterial />
+            </threeLine>
+          </Select>
+          <Select enabled>
+            <points ref={pointsRef}>
+              <bufferGeometry />
+              <pointsMaterial />
+            </points>
+          </Select>
+        </Selection>
+      )
+    )
+    await flush()
+    await flush()
+
+    const last = snapshots[snapshots.length - 1]
+    expect(last).toContain(lineRef.current)
+    expect(last).toContain(pointsRef.current)
+  })
+
+  it('removes its objects once unmounted, leaving a sibling Select untouched', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const meshARef = React.createRef<THREE.Mesh>()
+    const meshBRef = React.createRef<THREE.Mesh>()
+
+    const render = (mountA: boolean) =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          {mountA && (
+            <Select key="a" enabled>
+              <mesh ref={meshARef}>
+                <boxGeometry />
+                <meshBasicMaterial />
+              </mesh>
+            </Select>
+          )}
+          <Select key="b" enabled>
+            <mesh ref={meshBRef}>
+              <boxGeometry />
+              <meshBasicMaterial />
+            </mesh>
+          </Select>
+        </Selection>
+      )
+
+    await React.act(async () => render(true))
+    await flush()
+    await flush()
+    expect(snapshots[snapshots.length - 1]).toEqual(
+      expect.arrayContaining([meshARef.current, meshBRef.current])
+    )
+
+    await React.act(async () => render(false))
+    await flush()
+    await flush()
+
+    const last = snapshots[snapshots.length - 1]
+    expect(last).not.toContain(meshARef.current)
+    expect(last).toContain(meshBRef.current)
+  })
+
+  it('removes its objects when enabled toggles to false', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const meshRef = React.createRef<THREE.Mesh>()
+
+    const render = (enabled: boolean) =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          <Select enabled={enabled}>
+            <mesh ref={meshRef}>
+              <boxGeometry />
+              <meshBasicMaterial />
+            </mesh>
+          </Select>
+        </Selection>
+      )
+
+    await React.act(async () => render(true))
+    await flush()
+    await flush()
+    expect(snapshots[snapshots.length - 1]).toContain(meshRef.current)
+
+    await React.act(async () => render(false))
+    await flush()
+    await flush()
+    expect(snapshots[snapshots.length - 1]).not.toContain(meshRef.current)
+  })
+
+  it('selects a SkinnedMesh - isMesh is inherited, not just the exact type string', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const meshRef = React.createRef<THREE.SkinnedMesh>()
+
+    await React.act(async () =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          <Select enabled>
+            <skinnedMesh ref={meshRef} />
+          </Select>
+        </Selection>
+      )
+    )
+    await flush()
+    await flush()
+
+    expect(snapshots[snapshots.length - 1]).toContain(meshRef.current)
+  })
+
+  it('does not duplicate an object claimed by nested Selects', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const meshRef = React.createRef<THREE.Mesh>()
+
+    await React.act(async () =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          <Select enabled>
+            <Select enabled>
+              <mesh ref={meshRef}>
+                <boxGeometry />
+                <meshBasicMaterial />
+              </mesh>
+            </Select>
+          </Select>
+        </Selection>
+      )
+    )
+    await flush()
+    await flush()
+    await flush()
+
+    const last = snapshots[snapshots.length - 1]
+    expect(last.filter((o) => o === meshRef.current)).toHaveLength(1)
+  })
+
+  it('keeps an object selected via the outer Select after the inner one disables', async () => {
+    const snapshots: THREE.Object3D[][] = []
+    const meshRef = React.createRef<THREE.Mesh>()
+
+    const render = (innerEnabled: boolean) =>
+      root.render(
+        <Selection>
+          <Capture onSnapshot={(s) => snapshots.push(s)} />
+          <Select enabled>
+            <Select enabled={innerEnabled}>
+              <mesh ref={meshRef}>
+                <boxGeometry />
+                <meshBasicMaterial />
+              </mesh>
+            </Select>
+          </Select>
+        </Selection>
+      )
+
+    await React.act(async () => render(true))
+    await flush()
+    await flush()
+    await flush()
+    expect(snapshots[snapshots.length - 1]).toContain(meshRef.current)
+
+    await React.act(async () => render(false))
+    await flush()
+    await flush()
+    await flush()
+
+    // The inner Select's own cleanup drops its claim, but the mesh never
+    // left the outer Select's subtree - its own traversal still finds it.
+    expect(snapshots[snapshots.length - 1]).toContain(meshRef.current)
+  })
+})


### PR DESCRIPTION
Select's effect kept the context value (`api`) in its own dependency array, and returned a cleanup that undoes its own write. Every selection change made `api` change identity via context, which retriggered the effect, which first ran the stale cleanup and undid the write, which retriggered again - an unbounded loop that eventually throws "Maximum update depth exceeded".

Fix: depend only on the stable `select` setter (never changes identity), diff against latest state inside the functional updater instead of a render-scope snapshot, and bail with the same array reference when nothing changed. Also fixes the type check (`o.type === 'Mesh'` → `isMesh || isLine || isPoints`) so Line/Points/SkinnedMesh are selectable too.

Fixes #260, fixes #330, fixes #236, fixes #134, fixes #134

Supersedes #237, #335, #340, #342  four independent attempts at the same fix, each with a partial gap.

Test plan: 7 new tests - no-loop settling, Line/Points selection, SkinnedMesh, unmount cleanup, enabled toggling, nested `<Select>` dedup and OR-semantics.
