### PR TITLE
fix(LUT,Texture): make ref prop optional

### DIFF
--- a/src/effects/LUT.tsx
+++ b/src/effects/LUT.tsx
@@ -8,7 +8,7 @@ export type LUTProps = {
   lut: Texture
   blendFunction?: BlendFunction
   tetrahedralInterpolation?: boolean
-  ref: Ref<LUT3DEffect>
+  ref?: Ref<LUT3DEffect>
 }
 
 export function LUT({ lut, tetrahedralInterpolation, ref, ...props }: LUTProps) {

--- a/src/effects/Texture.tsx
+++ b/src/effects/Texture.tsx
@@ -8,7 +8,7 @@ type TextureProps = ConstructorParameters<typeof TextureEffect>[0] & {
   textureSrc: string
   /** opacity of provided texture */
   opacity?: number
-  ref: Ref<TextureEffect>
+  ref?: Ref<TextureEffect>
 }
 
 export function Texture({ textureSrc, texture, opacity = 1, ref, ...props }: TextureProps) {


### PR DESCRIPTION
- `LUTProps.ref` and `TextureProps.ref` were typed as required, unlike `ref?` on every other effect component - forced consumers to pass a `ref` even when they don't need one.
- Found while visually smoke-testing all effects after #360.