### PR TITLE
Build the docs with pmndrs/docs@v4

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   build:
-    uses: pmndrs/docs/.github/workflows/build.yml@v3
+    uses: pmndrs/docs/.github/workflows/build.yml@v4
     with:
       mdx: 'docs'
       libname: 'React Postprocessing'


### PR DESCRIPTION
One line: the reusable workflow moves from `@v3`/`@v2` to `@v4`.

[pmndrs/docs v4](https://github.com/pmndrs/docs/releases/tag/v4.0.0) drops the Docker image. The workflow now builds through `npx @pmndrs/docs@latest` instead of `docker run ghcr.io/pmndrs/docs`.

Nothing else changes for this repository: the same inputs, the same environment variables, the same GitHub Pages artifact. The only removed input is `docker_tag`, which this workflow never passed.

The old tag stays where it is, so this repository keeps building on the Docker path until this merges.

> [!NOTE]
> These workflows only trigger on a push to the default branch, so this pull request runs no build of its own — the first real run happens after the merge.
